### PR TITLE
fix: handle missed agent_end events to prevent stuck message sends

### DIFF
--- a/src/lib/server/cache.ts
+++ b/src/lib/server/cache.ts
@@ -60,9 +60,21 @@ export function getDb(): Database {
 			dev_command TEXT
 		)`);
 
+		db.run(`CREATE TABLE IF NOT EXISTS session_events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			event_type TEXT NOT NULL,
+			timestamp TEXT NOT NULL,
+			message_id TEXT,
+			metadata TEXT,
+			FOREIGN KEY (session_id) REFERENCES active_sessions(session_id)
+		)`);
+
 		db.run('CREATE INDEX IF NOT EXISTS idx_meta_mtime ON session_meta(mtime_ms)');
 		db.run('CREATE INDEX IF NOT EXISTS idx_meta_last_modified ON session_meta(last_modified)');
 		db.run('CREATE INDEX IF NOT EXISTS idx_active_status ON active_sessions(status)');
+		db.run('CREATE INDEX IF NOT EXISTS idx_events_session ON session_events(session_id)');
+		db.run('CREATE INDEX IF NOT EXISTS idx_events_timestamp ON session_events(timestamp)');
 	}
 	return db;
 }
@@ -163,4 +175,25 @@ export async function pruneCache() {
 
 export function warmCache(scanAndParse: () => Promise<void>) {
 	setTimeout(() => scanAndParse(), 100);
+}
+
+// Session Events
+export interface SessionEvent {
+	id: number;
+	session_id: string;
+	event_type: string;
+	timestamp: string;
+	message_id: string | null;
+	metadata: string | null;
+}
+
+export function insertSessionEvent(sessionId: string, eventType: string, messageId?: string, metadata?: Record<string, any>) {
+	getDb().run(
+		'INSERT INTO session_events (session_id, event_type, timestamp, message_id, metadata) VALUES (?, ?, ?, ?, ?)',
+		[sessionId, eventType, new Date().toISOString(), messageId ?? null, metadata ? JSON.stringify(metadata) : null]
+	);
+}
+
+export function getSessionEvents(sessionId: string): SessionEvent[] {
+	return getDb().query('SELECT * FROM session_events WHERE session_id = ? ORDER BY timestamp ASC').all(sessionId) as SessionEvent[];
 }

--- a/src/lib/server/init.ts
+++ b/src/lib/server/init.ts
@@ -5,11 +5,13 @@ import { startWatching } from './session-watcher';
 import { homedir } from 'os';
 import { join } from 'path';
 
-let initialized = false;
+// Use globalThis to survive HMR module re-evaluation
+const g = globalThis as any;
+if (g.__piInitialized === undefined) g.__piInitialized = false;
 
 export async function ensureInit() {
-	if (initialized) return;
-	initialized = true;
+	if (g.__piInitialized) return;
+	g.__piInitialized = true;
 
 	await pruneCache();
 	registerCacheInvalidation();

--- a/src/lib/server/logger.ts
+++ b/src/lib/server/logger.ts
@@ -1,0 +1,29 @@
+import { appendFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const LOG_DIR = join(tmpdir(), 'pi-remote-web');
+const LOG_FILE = join(LOG_DIR, 'debug.log');
+
+try { mkdirSync(LOG_DIR, { recursive: true }); } catch {}
+
+function timestamp(): string {
+	return new Date().toISOString();
+}
+
+function write(level: string, tag: string, ...args: any[]) {
+	const msg = args.map(a =>
+		typeof a === 'string' ? a : JSON.stringify(a, null, 0)
+	).join(' ');
+	const line = `${timestamp()} [${level}] [${tag}] ${msg}\n`;
+	try {
+		appendFileSync(LOG_FILE, line);
+	} catch { /* best effort */ }
+}
+
+export const log = {
+	info: (tag: string, ...args: any[]) => write('INFO', tag, ...args),
+	warn: (tag: string, ...args: any[]) => write('WARN', tag, ...args),
+	error: (tag: string, ...args: any[]) => write('ERROR', tag, ...args),
+	file: LOG_FILE,
+};

--- a/src/lib/server/pi-relay.ts
+++ b/src/lib/server/pi-relay.ts
@@ -64,14 +64,29 @@ async function pumpStdout() {
 }
 pumpStdout().catch(() => {});
 
-// Consume stderr
+// Consume stderr and log to file
+import { appendFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+const LOG_FILE = join(tmpdir(), 'pi-remote-web', 'debug.log');
+function relayLog(msg: string) {
+	try { appendFileSync(LOG_FILE, `${new Date().toISOString()} [INFO] [relay-daemon] ${msg}\n`); } catch {}
+}
+
 if (proc.stderr) {
-	new Response(proc.stderr as ReadableStream).text().then(text => {
-		if (text.trim()) {
-			// Write to our stderr so it's not lost
-			process.stderr.write(`[pi stderr] ${text.slice(0, 4000)}\n`);
+	const stderrReader = (proc.stderr as ReadableStream).getReader();
+	const stderrDecoder = new TextDecoder();
+	(async () => {
+		while (true) {
+			const { done, value } = await stderrReader.read();
+			if (done) break;
+			const text = stderrDecoder.decode(value, { stream: true });
+			if (text.trim()) {
+				relayLog(`[pi stderr] ${text.trim().slice(0, 2000)}`);
+				process.stderr.write(`[pi stderr] ${text.slice(0, 4000)}\n`);
+			}
 		}
-	}).catch(() => {});
+	})().catch(() => {});
 }
 
 // Listen for client connections
@@ -105,8 +120,10 @@ writeFileSync(pidPath, String(process.pid));
 
 // When pi exits, notify clients and shut down
 proc.exited.then((code) => {
+	const signalCode = proc.signalCode;
+	relayLog(`pi exited: code=${code} signal=${signalCode} pid=${proc.pid} clients=${clients.size}`);
 	dead = true;
-	const msg = JSON.stringify({ type: 'session_ended' }) + '\n';
+	const msg = JSON.stringify({ type: 'session_ended', exitCode: code, signal: signalCode }) + '\n';
 	const encoded = new TextEncoder().encode(msg);
 	for (const client of [...clients]) {
 		try {
@@ -122,6 +139,7 @@ proc.exited.then((code) => {
 
 // Handle signals — forward to pi and exit
 function handleSignal(signal: string) {
+	relayLog(`received signal: ${signal} — killing pi (pid=${proc.pid})`);
 	if (signal === 'SIGUSR1') {
 		// Graceful: kill pi, clean up
 		proc.kill();

--- a/src/lib/server/rpc-manager.ts
+++ b/src/lib/server/rpc-manager.ts
@@ -2,8 +2,9 @@ import { existsSync, unlinkSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir, homedir } from 'os';
-import { getDb } from './cache';
+import { getDb, insertSessionEvent } from './cache';
 import { encodeSessionId } from './session-scanner';
+import { log } from './logger';
 import type { Socket } from 'bun';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -43,7 +44,7 @@ interface ActiveSessionRow {
 
 const MAX_STREAMING_TEXT = 100 * 1024;
 const COMMAND_TIMEOUT_MS = 30_000;
-const AUTO_STOP_DELAY_MS = 1500;
+
 const RELAY_SCRIPT = join(__dirname, 'pi-relay.ts');
 const SOCKET_DIR = join(tmpdir(), 'pi-remote-web');
 
@@ -121,11 +122,13 @@ function sendCommand(managed: ManagedSession, cmd: Record<string, any>): Promise
 		return Promise.reject(err);
 	}
 
+	
+
 	const promise = new Promise<any>((resolve, reject) => {
 		managed.pendingCommands.set(id, { resolve, reject });
 		setTimeout(() => {
 			if (managed.pendingCommands.delete(id)) {
-				console.warn(`RPC command timed out: ${cmd.type} (session: ${managed.sessionId})`);
+				log.warn('rpc', `command timed out: ${cmd.type} id=${id} session=${managed.sessionId} pendingCommands remaining: ${managed.pendingCommands.size}`);
 				reject(new Error(`RPC command timed out: ${cmd.type}`));
 			}
 		}, COMMAND_TIMEOUT_MS);
@@ -153,6 +156,7 @@ function processData(managed: ManagedSession, raw: Buffer | Uint8Array) {
 					if (parsed.success) {
 						pending.resolve(parsed.data ?? parsed);
 					} else {
+						log.error('rpc', `command failed: ${parsed.command} error=${parsed.error}`);
 						pending.reject(new Error(parsed.error ?? 'RPC command failed'));
 					}
 				}
@@ -166,6 +170,7 @@ function processData(managed: ManagedSession, raw: Buffer | Uint8Array) {
 				managed.lastAgentStartTime = Date.now();
 				managed.streamingAssistantText = '';
 				managed.streamingThinkingText = '';
+				insertSessionEvent(managed.sessionId, 'agent_start');
 				if (managed.autoStopTimer) {
 					clearTimeout(managed.autoStopTimer);
 					managed.autoStopTimer = null;
@@ -176,17 +181,17 @@ function processData(managed: ManagedSession, raw: Buffer | Uint8Array) {
 				managed.lastAgentStartTime = null;
 				managed.streamingAssistantText = '';
 				managed.streamingThinkingText = '';
-				if (managed.autoStopTimer) clearTimeout(managed.autoStopTimer);
-				managed.autoStopTimer = setTimeout(() => {
-					managed.autoStopTimer = null;
-					if (!managed.isStreaming && activeSessions.has(managed.sessionId)) {
-						stopSession(managed.sessionId);
-					}
-				}, AUTO_STOP_DELAY_MS);
+				insertSessionEvent(managed.sessionId, 'agent_end');
 			}
 			if (parsed.type === 'session_ended') {
 				handleSessionEnded(managed);
 				return; // Stop processing — session is done
+			}
+			if (parsed.type === 'auto_compaction_start') {
+				insertSessionEvent(managed.sessionId, 'compaction_start');
+			}
+			if (parsed.type === 'auto_compaction_end') {
+				insertSessionEvent(managed.sessionId, 'compaction_end');
 			}
 			if (parsed.type === 'message_update') {
 				const ame = parsed.assistantMessageEvent;
@@ -217,6 +222,7 @@ function processData(managed: ManagedSession, raw: Buffer | Uint8Array) {
 // --- Handle session ended (relay reported pi exited) ---
 
 function handleSessionEnded(managed: ManagedSession) {
+	insertSessionEvent(managed.sessionId, 'session_ended');
 	if (managed.autoStopTimer) {
 		clearTimeout(managed.autoStopTimer);
 		managed.autoStopTimer = null;
@@ -247,7 +253,7 @@ async function spawnRelay(
 	cwd: string,
 	piArgs: string[]
 ): Promise<number> {
-	console.log(`Spawning relay: ${RELAY_SCRIPT} ${socketPath} ${cwd} ${piArgs.join(' ')}`);
+	log.info('relay', `spawning: ${RELAY_SCRIPT} ${socketPath} ${cwd} ${piArgs.join(' ')}`);
 
 	// Spawn relay as a detached process that survives our exit.
 	// Use stdin/stdout/stderr: 'ignore' so no pipe ties us to the child.
@@ -276,7 +282,7 @@ async function spawnRelay(
 		if (existsSync(pidPath) && existsSync(socketPath)) {
 			const pid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10);
 			if (pid > 0 && isProcessAlive(pid)) {
-				console.log(`Relay ready: pid ${pid}`);
+				log.info('relay', `ready: pid ${pid}`);
 				return pid;
 			}
 		}
@@ -306,7 +312,7 @@ async function connectToRelay(managed: ManagedSession): Promise<void> {
 						}
 					},
 					error(_socket, err) {
-						console.error(`Socket error for ${managed.sessionId}:`, err.message);
+						log.error('socket', `error for ${managed.sessionId}: ${err.message}`);
 					},
 				},
 			});
@@ -364,6 +370,9 @@ export async function resumeSession(
 		await connectToRelay(managed);
 		activeSessions.set(sessionId, managed);
 		updatePidStmt.run(relayPid, 'running', sessionId);
+
+		// Record session resumed event
+		insertSessionEvent(sessionId, 'session_resumed');
 
 		// Sync streaming state
 		try {
@@ -447,6 +456,9 @@ export async function createSession(cwd: string, model?: string): Promise<string
 		socketPath
 	);
 
+	// Record session created event
+	insertSessionEvent(sessionId, 'session_created');
+
 	return sessionId;
 }
 
@@ -456,14 +468,38 @@ export async function sendMessage(
 	behavior?: 'steer' | 'followUp'
 ): Promise<any> {
 	const managed = activeSessions.get(sessionId);
-	if (!managed) throw new Error('Session not active');
+	if (!managed) {
+		
+		throw new Error('Session not active');
+	}
+
+	// If we think we're streaming, verify with pi's actual state
+	// to handle missed agent_end events
+	let actuallyStreaming = managed.isStreaming;
+	if (actuallyStreaming && !behavior) {
+		try {
+			const state = await sendCommand(managed, { type: 'get_state' });
+			actuallyStreaming = state.isStreaming || (state.pendingMessageCount ?? 0) > 0;
+			if (!actuallyStreaming && managed.isStreaming) {
+				log.warn('sendMessage', `correcting streaming state — pi says not streaming, resetting`);
+				managed.isStreaming = false;
+				managed.lastAgentStartTime = null;
+				managed.streamingAssistantText = '';
+				managed.streamingThinkingText = '';
+			}
+		} catch {
+			// If get_state fails, fall back to local state
+		}
+	}
+
+	
 
 	if (behavior === 'steer') {
 		return sendCommand(managed, { type: 'steer', message });
 	} else if (behavior === 'followUp') {
 		return sendCommand(managed, { type: 'follow_up', message });
 	} else {
-		if (managed.isStreaming) {
+		if (actuallyStreaming) {
 			return sendCommand(managed, { type: 'follow_up', message });
 		}
 		return sendCommand(managed, { type: 'prompt', message });
@@ -485,6 +521,9 @@ export async function abortSession(sessionId: string): Promise<void> {
 export async function stopSession(sessionId: string): Promise<void> {
 	const managed = activeSessions.get(sessionId);
 	if (managed) {
+		
+		// Record event before stopping
+		insertSessionEvent(sessionId, 'session_stopped');
 		// Send SIGUSR1 to relay — it will kill pi, notify us via session_ended, then exit
 		try {
 			process.kill(managed.relayPid, 'SIGUSR1');
@@ -618,12 +657,24 @@ export async function recoverActiveSessions() {
 			continue;
 		}
 
+		// If already connected in-memory, skip — avoids duplicate connections on HMR
+		const existing = activeSessions.get(row.session_id);
+		if (existing?.socket) {
+			log.info('recovery', `already connected: ${row.session_id} — skipping`);
+			continue;
+		}
+
+		// Close any stale socket from a previous in-memory entry
+		if (existing) {
+			try { existing.socket?.end(); } catch {}
+		}
+
 		const socketPath = row.socket_path || socketPathFor(row.session_id);
 		const relayPid = getRelayPid(socketPath);
 
 		if (relayPid) {
 			// Relay is still alive! Just reconnect.
-			console.log(`Reconnecting to live relay: ${row.session_id} (pid ${relayPid})`);
+			log.info('recovery', `reconnecting to live relay: ${row.session_id} (pid ${relayPid})`);
 			try {
 				const managed: ManagedSession = {
 					sessionId: row.session_id,
@@ -658,7 +709,7 @@ export async function recoverActiveSessions() {
 				reconnected++;
 				continue;
 			} catch (err) {
-				console.error(`Failed to reconnect to relay ${row.session_id}:`, err);
+				log.error('recovery', `failed to reconnect to relay ${row.session_id}: ${err}`);
 				killRelay(relayPid, socketPath);
 			}
 		} else {
@@ -672,25 +723,25 @@ export async function recoverActiveSessions() {
 			}
 		}
 
-		console.log(`Recovering session: ${row.session_id} (${row.cwd})`);
+		log.info('recovery', `recovering session: ${row.session_id} (${row.cwd})`);
 		try {
 			await resumeSession(row.session_id, row.file_path, row.cwd);
 			recovered++;
 		} catch (err) {
-			console.error(`Failed to recover ${row.session_id}:`, err);
+			log.error('recovery', `failed to recover ${row.session_id}: ${err}`);
 			deleteActiveStmt.run(row.session_id);
 		}
 	}
 
 	if (rows.length > 0) {
-		console.log(`Recovery: ${reconnected} reconnected, ${recovered} respawned (of ${rows.length} total)`);
+		log.info('recovery', `${reconnected} reconnected, ${recovered} respawned (of ${rows.length} total)`);
 	}
 }
 
 // --- Graceful shutdown ---
 
 async function handleShutdown() {
-	console.log('Shutting down — disconnecting from relays (agents stay alive)...');
+	log.info('shutdown', 'disconnecting from relays (agents stay alive)...');
 
 	// Disconnect from all relays but DON'T kill them
 	for (const [, managed] of activeSessions) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,3 +101,14 @@ export interface ExtensionUIRequest {
 	text?: string;
 	[key: string]: any;
 }
+
+// --- Session Events ---
+
+export interface SessionEvent {
+	id: number;
+	session_id: string;
+	event_type: string;
+	timestamp: string;
+	message_id: string | null;
+	metadata: string | null;
+}

--- a/src/routes/api/sessions/[id]/events-log/+server.ts
+++ b/src/routes/api/sessions/[id]/events-log/+server.ts
@@ -1,0 +1,8 @@
+import { getSessionEvents } from '$lib/server/cache';
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ params }) => {
+	const events = getSessionEvents(params.id);
+	return json({ events });
+};

--- a/src/routes/api/sessions/[id]/state/+server.ts
+++ b/src/routes/api/sessions/[id]/state/+server.ts
@@ -1,4 +1,4 @@
-import { getState, isActive, getStreamingState } from '$lib/server/rpc-manager';
+import { getState, isActive, getStreamingState, resetStreaming } from '$lib/server/rpc-manager';
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
@@ -10,14 +10,15 @@ export const GET: RequestHandler = async ({ params }) => {
 		const state = await getState(params.id);
 		const local = getStreamingState(params.id);
 
-		// Cross-check: if our server thinks we're streaming but pi's RPC
-		// says it's not streaming AND there are no pending messages,
-		// trust pi — the agent_end event was likely missed.
-		// We don't mutate server state here (GET should be side-effect free);
-		// the client uses this to decide whether to show streaming UI.
 		const effectiveStreaming = local.isStreaming
 			? (state.isStreaming || (state.pendingMessageCount ?? 0) > 0)
 			: false;
+
+		// Fix server state if pi says not streaming but we think it is
+		// This handles missed agent_end events
+		if (local.isStreaming && !effectiveStreaming) {
+			resetStreaming(params.id);
+		}
 
 		return json({ active: true, ...state, isStreaming: effectiveStreaming });
 	} catch (e) {

--- a/src/routes/session/[id]/+page.svelte
+++ b/src/routes/session/[id]/+page.svelte
@@ -7,7 +7,7 @@
 	import { timeAgo } from '$lib/utils';
 	import { getPathToNode, isAncestorOf, findLeafFrom, getBranchPoints } from '$lib/session-tree';
 	import { browser } from '$app/environment';
-	import type { AgentMessage, SessionTree, BranchPoint, ExtensionUIRequest } from '$lib/types';
+	import type { AgentMessage, SessionTree, BranchPoint, ExtensionUIRequest, SessionEvent } from '$lib/types';
 
 	let { data } = $props();
 
@@ -36,6 +36,10 @@
 
 	// SSE connection state (Issue 3)
 	let sseConnected = $state(false);
+
+	// Session events
+	let sessionEvents = $state<SessionEvent[]>([]);
+	let showEvents = $state(false);
 
 	// Extension UI
 	let extensionUIRequest = $state<ExtensionUIRequest | null>(null);
@@ -115,6 +119,19 @@
 		}
 	}
 
+	// Load session events
+	async function loadEvents() {
+		try {
+			const res = await fetch(`/api/sessions/${data.sessionId}/events-log`);
+			if (res.ok) {
+				const result = await res.json();
+				sessionEvents = result.events;
+			}
+		} catch (e) {
+			console.error('Failed to load events:', e);
+		}
+	}
+
 	// Reload just the full messages (used after agent_end)
 	async function reloadMessages() {
 		try {
@@ -132,12 +149,15 @@
 		} catch (e) {
 			console.error('Failed to reload messages:', e);
 		}
+		// Also reload events
+		loadEvents();
 	}
 
 	// Load on mount and when session changes
 	$effect(() => {
 		data.sessionId;
 		loadTail();
+		loadEvents();
 	});
 
 	// Remember this project as expanded for dashboard navigation
@@ -203,12 +223,30 @@
 					currentAssistantText = '';
 					currentThinkingText = '';
 					waitingForAgent = false; // Agent has started, clear waiting state
+					// Add to session events
+					sessionEvents = [...sessionEvents, {
+						id: sessionEvents.length + 1,
+						session_id: data.sessionId,
+						event_type: 'agent_start',
+						timestamp: new Date().toISOString(),
+						message_id: null,
+						metadata: null
+					}];
 					break;
 				case 'agent_end':
 					streaming = false;
 					currentAssistantText = '';
 					currentThinkingText = '';
 					reloadMessages();
+					// Add to session events
+					sessionEvents = [...sessionEvents, {
+						id: sessionEvents.length + 1,
+						session_id: data.sessionId,
+						event_type: 'agent_end',
+						timestamp: new Date().toISOString(),
+						message_id: null,
+						metadata: null
+					}];
 					break;
 				case 'session_ended':
 					streaming = false;
@@ -216,6 +254,15 @@
 					eventSource?.close();
 					eventSource = null;
 					reloadMessages();
+					// Add to session events
+					sessionEvents = [...sessionEvents, {
+						id: sessionEvents.length + 1,
+						session_id: data.sessionId,
+						event_type: 'session_ended',
+						timestamp: new Date().toISOString(),
+						message_id: null,
+						metadata: null
+					}];
 					break;
 				case 'message_start':
 					if (event.message?.role === 'assistant') {
@@ -247,9 +294,27 @@
 					break;
 				case 'auto_compaction_start':
 					compacting = true;
+					// Add to session events
+					sessionEvents = [...sessionEvents, {
+						id: sessionEvents.length + 1,
+						session_id: data.sessionId,
+						event_type: 'compaction_start',
+						timestamp: new Date().toISOString(),
+						message_id: null,
+						metadata: null
+					}];
 					break;
 				case 'auto_compaction_end':
 					compacting = false;
+					// Add to session events
+					sessionEvents = [...sessionEvents, {
+						id: sessionEvents.length + 1,
+						session_id: data.sessionId,
+						event_type: 'compaction_end',
+						timestamp: new Date().toISOString(),
+						message_id: null,
+						metadata: null
+					}];
 					break;
 				case 'auto_retry_start':
 					retryInfo = {
@@ -363,12 +428,14 @@
 				const state = await res.json();
 				if (!state.active || !state.isStreaming) {
 					streaming = false;
+					waitingForAgent = false;
+					pendingUserMessage = null;
 					currentAssistantText = '';
 					currentThinkingText = '';
 					reloadMessages();
 				}
 			} catch { /* ignore */ }
-		}, 5000);
+		}, 1500);
 		return () => clearInterval(interval);
 	});
 
@@ -430,6 +497,35 @@
 		const leafId = findLeafFrom(tree, childId);
 		currentLeaf = leafId;
 		currentMessages = getPathToNode(tree, leafId);
+	}
+
+	// Event display helpers
+	function eventIcon(eventType: string): string {
+		switch (eventType) {
+			case 'session_created': return '🟢';
+			case 'session_resumed': return '⏯️';
+			case 'session_stopped': return '🛑';
+			case 'session_ended': return '🔴';
+			case 'agent_start': return '▶️';
+			case 'agent_end': return '⏹️';
+			case 'compaction_start': return '🗜️';
+			case 'compaction_end': return '✅';
+			default: return '•';
+		}
+	}
+
+	function eventLabel(eventType: string): string {
+		switch (eventType) {
+			case 'session_created': return 'Session created';
+			case 'session_resumed': return 'Session resumed';
+			case 'session_stopped': return 'Session stopped';
+			case 'session_ended': return 'Session ended';
+			case 'agent_start': return 'Agent started';
+			case 'agent_end': return 'Agent finished';
+			case 'compaction_start': return 'Compaction started';
+			case 'compaction_end': return 'Compaction finished';
+			default: return eventType;
+		}
 	}
 
 	// Handle message sent callback (Issue 1)
@@ -495,6 +591,9 @@
 				<span class="text-xs text-base-content/50">Restarting…</span>
 			{:else if sessionActive}
 				<!-- Desktop: inline buttons -->
+				<button class="btn btn-ghost btn-xs hidden md:inline-flex" onclick={() => showEvents = !showEvents}>
+					Activity
+				</button>
 				<button class="btn btn-ghost btn-xs text-error hidden md:inline-flex" onclick={handleAbort}>Abort</button>
 				<button class="btn btn-ghost btn-xs hidden md:inline-flex" onclick={handleRestart}>Restart</button>
 				<button class="btn btn-ghost btn-xs hidden md:inline-flex" onclick={handleStop}>Stop</button>
@@ -518,98 +617,126 @@
 		</div>
 	</div>
 
-	<!-- Chat messages -->
-	<div class="flex-1 overflow-y-auto overscroll-contain px-4 py-4" style="-webkit-overflow-scrolling: touch;" bind:this={chatContainer} onscroll={handleScroll}>
-		{#if loadingMessages}
-			<div class="flex items-center justify-center py-12">
-				<span class="loading loading-spinner loading-md"></span>
-				<span class="ml-2 text-base-content/50">Loading messages…</span>
-			</div>
-		{:else}
-			{#if hasMore}
-				<div class="text-center py-3">
-					{#if loadingFull}
-						<span class="loading loading-spinner loading-xs"></span>
-						<span class="text-xs text-base-content/40 ml-1">Loading earlier messages…</span>
-					{:else}
-						<button class="btn btn-ghost btn-xs text-base-content/40" onclick={loadFullHistory}>Load earlier messages</button>
-					{/if}
+	<!-- Main content area: chat + event sidebar -->
+	<div class="flex-1 flex flex-row overflow-hidden">
+		<!-- Chat messages -->
+		<div class="flex-1 overflow-y-auto overscroll-contain px-4 py-4" style="-webkit-overflow-scrolling: touch;" bind:this={chatContainer} onscroll={handleScroll}>
+			{#if loadingMessages}
+				<div class="flex items-center justify-center py-12">
+					<span class="loading loading-spinner loading-md"></span>
+					<span class="ml-2 text-base-content/50">Loading messages…</span>
 				</div>
-			{/if}
-			{#each currentMessages as entry (entry.id)}
-				{#if branchPoints.has(entry.id)}
-					<BranchIndicator branchPoint={branchPoints.get(entry.id)!} onselect={switchBranch} />
-				{/if}
-				<ChatBubble {entry} />
-			{/each}
-
-			<!-- Optimistic pending user message (Issue 1) -->
-			{#if pendingUserMessage}
-				<div class="chat chat-end mb-2">
-					<div class="chat-bubble chat-bubble-primary max-w-[85vw] md:max-w-xl opacity-70 animate-pulse">
-						<div class="whitespace-pre-wrap break-words text-sm">
-							{pendingUserMessage}
-						</div>
-					</div>
-				</div>
-			{/if}
-
-			<!-- Waiting for agent indicator (Issue 1) -->
-			{#if waitingForAgent && !streaming}
-				<div class="chat chat-start mb-2">
-					<div class="chat-bubble max-w-[85vw] md:max-w-xl opacity-50">
-						<span class="loading loading-dots loading-xs"></span>
-						<span class="text-xs ml-1">sending to agent…</span>
-					</div>
-				</div>
-			{/if}
-
-			<!-- Streaming assistant text -->
-			{#if streaming}
-				<div class="chat chat-start mb-2">
-					<div class="chat-bubble max-w-[85vw] md:max-w-xl">
-						{#if currentThinkingText}
-							<details class="mb-2 rounded bg-base-300/30 -mx-1" open>
-								<summary class="cursor-pointer text-xs py-1 px-2 opacity-70">Thinking…</summary>
-								<div class="text-xs font-mono whitespace-pre-wrap opacity-70 px-2 pb-2 max-h-48 overflow-y-auto">
-									{currentThinkingText}
-								</div>
-							</details>
+			{:else}
+				{#if hasMore}
+					<div class="text-center py-3">
+						{#if loadingFull}
+							<span class="loading loading-spinner loading-xs"></span>
+							<span class="text-xs text-base-content/40 ml-1">Loading earlier messages…</span>
+						{:else}
+							<button class="btn btn-ghost btn-xs text-base-content/40" onclick={loadFullHistory}>Load earlier messages</button>
 						{/if}
-						<div class="whitespace-pre-wrap break-words text-sm">
-							{currentAssistantText}
-						</div>
-						<span class="loading loading-dots loading-xs ml-1"></span>
 					</div>
-				</div>
-			{/if}
+				{/if}
+				{#each currentMessages as entry (entry.id)}
+					{#if branchPoints.has(entry.id)}
+						<BranchIndicator branchPoint={branchPoints.get(entry.id)!} onselect={switchBranch} />
+					{/if}
+					<ChatBubble {entry} />
+				{/each}
 
-			{#if compacting}
-				<div class="text-center py-4">
-					<span class="loading loading-spinner loading-sm"></span>
-					<span class="text-sm text-base-content/50 ml-2">Compacting context…</span>
-				</div>
-			{/if}
+				<!-- Optimistic pending user message (Issue 1) -->
+				{#if pendingUserMessage}
+					<div class="chat chat-end mb-2">
+						<div class="chat-bubble chat-bubble-primary max-w-[85vw] md:max-w-xl opacity-70 animate-pulse">
+							<div class="whitespace-pre-wrap break-words text-sm">
+								{pendingUserMessage}
+							</div>
+						</div>
+					</div>
+				{/if}
 
-			{#if retryInfo}
-				<div class="alert alert-warning text-sm my-2">
-					Retrying (attempt {retryInfo.attempt}/{retryInfo.maxAttempts})…
-				</div>
-			{/if}
+				<!-- Waiting for agent indicator (Issue 1) -->
+				{#if waitingForAgent && !streaming}
+					<div class="chat chat-start mb-2">
+						<div class="chat-bubble max-w-[85vw] md:max-w-xl opacity-50">
+							<span class="loading loading-dots loading-xs"></span>
+							<span class="text-xs ml-1">sending to agent…</span>
+						</div>
+					</div>
+				{/if}
 
-			{#if currentMessages.length === 0 && !streaming && !pendingUserMessage}
-				<div class="py-12 text-center text-base-content/50">
-					{#if sessionActive}
-						<p class="text-lg mb-2">Session ready</p>
-						<p class="text-sm flex items-center justify-center gap-2">
-							<span class="animate-bounce">↓</span>
-							Type a message to get started
-						</p>
+				<!-- Streaming assistant text -->
+				{#if streaming}
+					<div class="chat chat-start mb-2">
+						<div class="chat-bubble max-w-[85vw] md:max-w-xl">
+							{#if currentThinkingText}
+								<details class="mb-2 rounded bg-base-300/30 -mx-1" open>
+									<summary class="cursor-pointer text-xs py-1 px-2 opacity-70">Thinking…</summary>
+									<div class="text-xs font-mono whitespace-pre-wrap opacity-70 px-2 pb-2 max-h-48 overflow-y-auto">
+										{currentThinkingText}
+									</div>
+								</details>
+							{/if}
+							<div class="whitespace-pre-wrap break-words text-sm">
+								{currentAssistantText}
+							</div>
+							<span class="loading loading-dots loading-xs ml-1"></span>
+						</div>
+					</div>
+				{/if}
+
+				{#if compacting}
+					<div class="text-center py-4">
+						<span class="loading loading-spinner loading-sm"></span>
+						<span class="text-sm text-base-content/50 ml-2">Compacting context…</span>
+					</div>
+				{/if}
+
+				{#if retryInfo}
+					<div class="alert alert-warning text-sm my-2">
+						Retrying (attempt {retryInfo.attempt}/{retryInfo.maxAttempts})…
+					</div>
+				{/if}
+
+				{#if currentMessages.length === 0 && !streaming && !pendingUserMessage}
+					<div class="py-12 text-center text-base-content/50">
+						{#if sessionActive}
+							<p class="text-lg mb-2">Session ready</p>
+							<p class="text-sm flex items-center justify-center gap-2">
+								<span class="animate-bounce">↓</span>
+								Type a message to get started
+							</p>
+						{:else}
+							<p>Empty session</p>
+						{/if}
+					</div>
+				{/if}
+			{/if}
+		</div>
+
+		<!-- Event log sidebar (desktop only) -->
+		{#if showEvents}
+			<div class="hidden md:flex flex-col w-64 border-l border-base-300 bg-base-200/50 overflow-hidden">
+				<div class="p-3 text-sm font-semibold border-b border-base-300 flex items-center justify-between">
+					<span>Activity Log</span>
+					<button class="btn btn-ghost btn-xs" onclick={() => showEvents = false}>✕</button>
+				</div>
+				<div class="flex-1 overflow-y-auto p-2 space-y-1">
+					{#if sessionEvents.length === 0}
+						<div class="text-xs text-base-content/40 p-2">No events yet</div>
 					{:else}
-						<p>Empty session</p>
+						{#each sessionEvents as event (event.id)}
+							<div class="text-xs flex items-start gap-2 py-1.5 px-2 rounded hover:bg-base-300/50">
+								<span class="text-base">{eventIcon(event.event_type)}</span>
+								<div class="flex-1 min-w-0">
+									<div class="font-medium">{eventLabel(event.event_type)}</div>
+									<div class="text-base-content/40">{timeAgo(event.timestamp)}</div>
+								</div>
+							</div>
+						{/each}
 					{/if}
 				</div>
-			{/if}
+			</div>
 		{/if}
 	</div>
 


### PR DESCRIPTION
## Problem

Messages sent after the agent finishes work get stuck in "sending to agent" state forever.

## Root Cause

Pi's RPC mode does not reliably emit `agent_end` events. This caused `managed.isStreaming` to stay `true` permanently, making subsequent messages get sent as `follow_up` (queued for after current turn) instead of `prompt`. Since no turn was active, messages sat in pending state forever.

## Changes

### Core fix
- **`sendMessage`**: Verify streaming state with pi via `get_state` before deciding `prompt` vs `follow_up`; auto-correct if mismatched
- **State endpoint**: Reset streaming state when local/rpc mismatch detected (handles missed `agent_end`)

### UX improvements  
- **Streaming poll**: Reduced from 5s to 1.5s for faster UI clearing after agent finishes
- **Poll cleanup**: Clear `waitingForAgent` and `pendingUserMessage` when streaming ends via poll

### Stability
- **HMR guard**: Use `globalThis` for init flag to survive module re-evaluation, preventing duplicate recovery connections
- **Recovery guard**: Skip reconnection if already connected to relay
- **Remove auto-stop timer**: Was masking the real issue by killing sessions after agent turns

### Observability
- **File logger**: Add file-based logger at `$TMPDIR/pi-remote-web/debug.log` for server-side diagnostics
- **Relay logging**: Log pi exit code/signal and stderr to debug log
- **Session events**: Track session lifecycle events with activity log sidebar