### PR TITLE
fix: persist rpc-manager state on globalThis to survive HMR

### DIFF
--- a/src/lib/server/rpc-manager.ts
+++ b/src/lib/server/rpc-manager.ts
@@ -58,10 +58,15 @@ const STEER_TIMEOUT_MS = 60_000;
 const RELAY_SCRIPT = join(__dirname, 'pi-relay.ts');
 const SOCKET_DIR = join(tmpdir(), 'pi-remote-web');
 
-// --- State ---
+// --- State (stored on globalThis to survive Vite HMR module re-evaluation) ---
 
-const activeSessions = new Map<string, ManagedSession>();
-const resumingSessionIds = new Set<string>();
+const g = globalThis as any;
+if (!g.__piActiveSessions) g.__piActiveSessions = new Map<string, ManagedSession>();
+if (!g.__piResumingSessionIds) g.__piResumingSessionIds = new Set<string>();
+if (!g.__piLastEventUpdate) g.__piLastEventUpdate = new Map<string, number>();
+
+const activeSessions: Map<string, ManagedSession> = g.__piActiveSessions;
+const resumingSessionIds: Set<string> = g.__piResumingSessionIds;
 
 // --- SQLite persistence ---
 
@@ -88,7 +93,7 @@ try { mkdirSync(SOCKET_DIR, { recursive: true }); } catch {}
 
 // --- Throttled heartbeat ---
 
-const lastEventUpdate = new Map<string, number>();
+const lastEventUpdate: Map<string, number> = g.__piLastEventUpdate;
 function updateEventThrottled(sessionId: string) {
 	const now = Date.now();
 	if (now - (lastEventUpdate.get(sessionId) ?? 0) > 5000) {


### PR DESCRIPTION
## Problem

Active sessions disappear from the dashboard after Vite HMR module reloads. The relay processes keep running but the web server loses all socket connections and can't communicate with pi sessions.

## Root Cause

The `activeSessions`, `resumingSessionIds`, and `lastEventUpdate` maps in `rpc-manager.ts` were module-level `const` declarations. When Vite HMR re-evaluates the module, these reset to empty `new Map()` / `new Set()`. Meanwhile, `init.ts` uses `globalThis.__piInitialized` to skip `recoverActiveSessions()` on subsequent loads — so recovery never runs again.

## Fix

Move all critical state maps to `globalThis` so they survive HMR module reloads, matching the pattern already used in `init.ts`.