### PR TITLE
fix: use project-relative .worktrees/ for job worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ vite.config.ts.timestamp-*
 *.db
 *.sqlite
 
+# Job worktrees
+.worktrees/
+
 # Test artifacts
 test-results/
 playwright-report/

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -6,7 +6,6 @@ import { claimNextJob, updateJobStatus, type Job } from './job-queue';
 import { buildTaskPrompt, buildTaskFixPrompt, buildReviewPrompt } from './job-prompts';
 import { createSession, sendMessage } from './rpc-manager';
 import { log } from './logger';
-import { homedir } from 'os';
 import { join } from 'path';
 import { mkdirSync, existsSync, rmSync } from 'fs';
 import { execFileSync } from 'child_process';
@@ -14,7 +13,7 @@ import { execFileSync } from 'child_process';
 // --- Constants ---
 
 const POLL_INTERVAL_MS = 30_000;
-const WORKTREE_BASE = process.env.PI_WORKTREE_DIR || join(homedir(), '.pi', 'worktrees');
+const WORKTREE_BASE = process.env.PI_WORKTREE_DIR || join(process.cwd(), '.worktrees');
 
 // --- State ---
 


### PR DESCRIPTION
Pi prompts for write confirmation when sessions write to paths outside the project directory. Job worktrees were defaulting to `~/.pi/worktrees/` which is outside the project, triggering the prompt.

Changes the default to `.worktrees/` relative to the project root and adds it to `.gitignore`. Still overridable via `PI_WORKTREE_DIR` env var.