### PR TITLE
feat: install deps in worktrees and migrate sessions on cleanup

### DIFF
--- a/src/lib/server/job-completion.test.ts
+++ b/src/lib/server/job-completion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
-import { handleCompletion } from './job-completion';
+import { handleCompletion, cwdToSessionDirName } from './job-completion';
 import { createJob, getJob, getJobs, updateJobStatus } from './job-queue';
 import { getDb } from './cache';
 
@@ -155,6 +155,26 @@ describe('job-completion', () => {
 
 			const allJobs = getJobs();
 			expect(allJobs).toHaveLength(1); // No fix enqueued
+		});
+	});
+
+	describe('cwdToSessionDirName', () => {
+		it('converts absolute path to pi session dir name', () => {
+			expect(cwdToSessionDirName('/Users/jchan/code/my-project')).toBe(
+				'--Users-jchan-code-my-project--'
+			);
+		});
+
+		it('handles paths with colons (Windows-style)', () => {
+			expect(cwdToSessionDirName('C:\\Users\\dev\\project')).toBe(
+				'--C--Users-dev-project--'
+			);
+		});
+
+		it('strips leading slash', () => {
+			const result = cwdToSessionDirName('/foo/bar');
+			expect(result).toBe('--foo-bar--');
+			expect(result.startsWith('---')).toBe(false);
 		});
 	});
 });

--- a/src/lib/server/job-completion.ts
+++ b/src/lib/server/job-completion.ts
@@ -4,8 +4,10 @@
  */
 import { getJob, updateJobStatus, createJob, type Job } from './job-queue';
 import { log } from './logger';
-import { rmSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, rmSync, copyFileSync } from 'fs';
 import { execFileSync } from 'child_process';
+import { join, resolve } from 'path';
+import { homedir } from 'os';
 
 // --- Types ---
 
@@ -144,14 +146,66 @@ function applyLoopLogic(job: Job, payload: CompletionPayload): void {
 	}
 }
 
+// --- Session migration ---
+
+const SESSIONS_DIR = join(homedir(), '.pi', 'agent', 'sessions');
+
+/**
+ * Convert a cwd path to the session directory name pi uses.
+ * Mirrors pi's internal convention: `--path-parts--`
+ * Exported for testing.
+ */
+export function cwdToSessionDirName(cwd: string): string {
+	return `--${cwd.replace(/^[/\\]/, '').replace(/[/\\:]/g, '-')}--`;
+}
+
+/**
+ * Copy session files from the worktree's session directory to the repo's
+ * session directory so they appear under the correct project in the dashboard.
+ */
+function migrateWorktreeSessions(job: Job): void {
+	if (!job.worktree_path || !job.repo) return;
+
+	const worktreeSessionDir = join(SESSIONS_DIR, cwdToSessionDirName(resolve(job.worktree_path)));
+	const repoSessionDir = join(SESSIONS_DIR, cwdToSessionDirName(resolve(job.repo)));
+
+	if (!existsSync(worktreeSessionDir)) {
+		log.info('job-completion', `no worktree session dir to migrate: ${worktreeSessionDir}`);
+		return;
+	}
+
+	try {
+		mkdirSync(repoSessionDir, { recursive: true });
+
+		const files = readdirSync(worktreeSessionDir).filter(f => f.endsWith('.jsonl'));
+		for (const file of files) {
+			const src = join(worktreeSessionDir, file);
+			const dest = join(repoSessionDir, file);
+			copyFileSync(src, dest);
+		}
+
+		log.info('job-completion', `migrated ${files.length} session file(s) from worktree to repo: ${repoSessionDir}`);
+
+		// Remove the worktree session directory
+		rmSync(worktreeSessionDir, { recursive: true, force: true });
+		log.info('job-completion', `removed worktree session dir: ${worktreeSessionDir}`);
+	} catch (err) {
+		log.warn('job-completion', `failed to migrate worktree sessions: ${err}`);
+	}
+}
+
 // --- Worktree cleanup ---
 
 /**
- * Remove the git worktree using `git worktree remove` to properly unregister
- * it from git's tracking, then fall back to rmSync if git fails.
+ * Migrate session files to the repo's session directory, then remove the
+ * git worktree using `git worktree remove` to properly unregister it from
+ * git's tracking. Falls back to rmSync if git fails.
  */
 function cleanupWorktree(job: Job): void {
 	if (!job.worktree_path) return;
+
+	// Copy session files to repo's session directory before cleanup
+	migrateWorktreeSessions(job);
 
 	// Try git worktree remove first (uses repo path if available)
 	try {

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -199,7 +199,45 @@ function createWorktree(repoPath: string, job: Job): string {
 	}
 
 	log.info('job-poller', `created worktree for job ${job.id}: ${worktreePath}`);
+
+	// Install dependencies if a lockfile is present
+	installDependencies(worktreePath, job.id);
+
 	return worktreePath;
+}
+
+// --- Dependency installation ---
+
+/** Lockfile → installer command mapping (checked in priority order). */
+const LOCKFILE_INSTALLERS: Array<{ lockfile: string; command: string; args: string[] }> = [
+	{ lockfile: 'bun.lockb', command: 'bun', args: ['install', '--frozen-lockfile'] },
+	{ lockfile: 'bun.lock', command: 'bun', args: ['install', '--frozen-lockfile'] },
+	{ lockfile: 'pnpm-lock.yaml', command: 'pnpm', args: ['install', '--frozen-lockfile'] },
+	{ lockfile: 'yarn.lock', command: 'yarn', args: ['install', '--frozen-lockfile'] },
+	{ lockfile: 'package-lock.json', command: 'npm', args: ['ci'] },
+];
+
+/**
+ * Detect the package manager from lockfiles and run the installer.
+ * Skips silently if no lockfile is found.
+ */
+function installDependencies(worktreePath: string, jobId: string): void {
+	for (const { lockfile, command, args } of LOCKFILE_INSTALLERS) {
+		if (existsSync(join(worktreePath, lockfile))) {
+			try {
+				log.info('job-poller', `installing dependencies for job ${jobId}: ${command} ${args.join(' ')}`);
+				execFileSync(command, args, {
+					cwd: worktreePath,
+					stdio: 'pipe',
+					timeout: 120_000,
+				});
+				log.info('job-poller', `dependencies installed for job ${jobId}`);
+			} catch (err: any) {
+				log.warn('job-poller', `dependency install failed for job ${jobId}: ${err.message}`);
+			}
+			return; // Only run the first matching installer
+		}
+	}
 }
 
 // --- Prompt building ---


### PR DESCRIPTION
## Changes

### 1. Auto-install dependencies after worktree creation
Detects the package manager from lockfiles and runs the appropriate installer:
- `bun.lockb` / `bun.lock` → `bun install --frozen-lockfile`
- `pnpm-lock.yaml` → `pnpm install --frozen-lockfile`
- `yarn.lock` → `yarn install --frozen-lockfile`
- `package-lock.json` → `npm ci`

### 2. Migrate session files on job completion
Before cleaning up the worktree, copies session `.jsonl` files from the worktree's session directory (`~/.pi/agent/sessions/--worktree-path--/`) to the repo's session directory (`~/.pi/agent/sessions/--repo-path--/`). This ensures job sessions appear under the correct project in the dashboard after the worktree is removed.