### PR TITLE
fix: guard against undefined session ID in API calls

### DIFF
--- a/src/lib/server/session-scanner.ts
+++ b/src/lib/server/session-scanner.ts
@@ -15,6 +15,9 @@ export function encodeSessionId(filePath: string): string {
 }
 
 export function decodeSessionId(id: string): string {
+	if (!id || id === 'undefined' || id === 'null') {
+		throw new Error('Invalid session ID: missing or empty');
+	}
 	const filePath = Buffer.from(id, 'base64url').toString();
 	const resolved = resolve(filePath);
 	if (!resolved.startsWith(SESSIONS_DIR)) {

--- a/src/routes/session/[id]/+page.svelte
+++ b/src/routes/session/[id]/+page.svelte
@@ -95,6 +95,7 @@
 	let loadingFull = $state(false);
 
 	async function loadTail() {
+		if (!data.sessionId) return;
 		loadingMessages = true;
 		try {
 			const res = await fetch(`/api/sessions/${data.sessionId}/messages/tail?count=20`);
@@ -115,6 +116,7 @@
 	}
 
 	async function loadFullHistory() {
+		if (!data.sessionId) return;
 		loadingFull = true;
 		try {
 			const res = await fetch(`/api/sessions/${data.sessionId}/messages`);
@@ -137,6 +139,7 @@
 
 	// Load session events
 	async function loadEvents() {
+		if (!data.sessionId) return;
 		try {
 			const res = await fetch(`/api/sessions/${data.sessionId}/events-log`);
 			if (res.ok) {
@@ -150,6 +153,7 @@
 
 	// Reload just the full messages (used after agent_end)
 	async function reloadMessages() {
+		if (!data.sessionId) return;
 		try {
 			const res = await fetch(`/api/sessions/${data.sessionId}/messages`);
 			if (res.ok) {
@@ -171,6 +175,7 @@
 
 	// Load on mount and when session changes
 	$effect(() => {
+		if (!data.sessionId) return;
 		data.sessionId;
 		loadTail();
 		loadEvents();


### PR DESCRIPTION
Fixes repeated 500 errors from `GET /api/sessions/undefined/messages`.

Client-side fetch functions now early-return when `data.sessionId` is falsy (can happen during navigation transitions). `decodeSessionId` also explicitly rejects the literal strings 'undefined' and 'null' with a clearer error.