### PR TITLE
fix: review jobs run in repo cwd, defer worktree cleanup

### DIFF
--- a/src/lib/server/job-completion.test.ts
+++ b/src/lib/server/job-completion.test.ts
@@ -45,14 +45,14 @@ describe('job-completion', () => {
 			expect(allJobs).toHaveLength(1);
 		});
 
-		it('completes a task and enqueues a review', () => {
+		it('completes a task and enqueues a review with inherited worktree_path', () => {
 			const job = createJob({
 				type: 'task',
 				title: 'Implement feature',
 				repo: '/repo',
 				branch: 'feat/test',
 			});
-			updateJobStatus(job.id, { status: 'running' });
+			updateJobStatus(job.id, { status: 'running', worktree_path: '/tmp/worktree-123' });
 
 			const result = handleCompletion(job.id, {
 				jobId: job.id,
@@ -72,6 +72,8 @@ describe('job-completion', () => {
 			expect(reviewJob!.parent_job_id).toBe(job.id);
 			expect(reviewJob!.status).toBe('queued');
 			expect(reviewJob!.pr_url).toBe('https://github.com/org/repo/pull/1');
+			// Review inherits the worktree path for cleanup after review
+			expect(reviewJob!.worktree_path).toBe('/tmp/worktree-123');
 		});
 
 		it('completes a review with approved verdict — no follow-up', () => {

--- a/src/lib/server/job-completion.ts
+++ b/src/lib/server/job-completion.ts
@@ -64,11 +64,16 @@ export function handleCompletion(jobId: string, payload: CompletionPayload): Job
 
 	const updatedJob = updateJobStatus(jobId, updates)!;
 
-	// Clean up worktree now that the job is done
-	cleanupWorktree(job);
+	// Apply loop logic based on job type and result.
+	// Worktree cleanup is deferred — task worktrees stay alive until the
+	// review completes (or the chain ends).
+	const followUpCreated = applyLoopLogic(updatedJob, payload);
 
-	// Apply loop logic based on job type and result
-	applyLoopLogic(updatedJob, payload);
+	// Only clean up the worktree if no follow-up job was created.
+	// For task→review chains, the worktree is cleaned up after the review.
+	if (!followUpCreated) {
+		cleanupWorktree(job);
+	}
 
 	return updatedJob;
 }
@@ -79,10 +84,12 @@ export function handleCompletion(jobId: string, payload: CompletionPayload): Job
  * After a job completes, determine whether to enqueue a follow-up:
  * - Task done → enqueue Review (if loop_count < max_loops)
  * - Review changes_requested → enqueue Task fix (increment loop_count)
- * - Review approved → done, no follow-up
+ * - Review approved → done, clean up worktree
  * - Loop cap reached → done with note
+ *
+ * Returns true if a follow-up job was created (worktree cleanup should be deferred).
  */
-function applyLoopLogic(job: Job, payload: CompletionPayload): void {
+function applyLoopLogic(job: Job, payload: CompletionPayload): boolean {
 	if (job.type === 'task') {
 		// Task completed — enqueue a review if we haven't exceeded loop cap
 		if (job.loop_count >= job.max_loops) {
@@ -90,7 +97,7 @@ function applyLoopLogic(job: Job, payload: CompletionPayload): void {
 			updateJobStatus(job.id, {
 				result_summary: (job.result_summary ?? '') + '\n[Loop cap reached — skipped automatic review]',
 			});
-			return;
+			return false;
 		}
 
 		const reviewJob = createJob({
@@ -108,11 +115,20 @@ function applyLoopLogic(job: Job, payload: CompletionPayload): void {
 			review_skill: job.review_skill ?? undefined,
 		});
 
+		// Pass worktree path to the review job so it can be cleaned up
+		// after the review (or passed to a fix job if changes are requested)
+		if (job.worktree_path) {
+			updateJobStatus(reviewJob.id, { worktree_path: job.worktree_path });
+		}
+
 		log.info('job-completion', `enqueued review job ${reviewJob.id} for task ${job.id}`);
+		return true;
 	} else if (job.type === 'review') {
 		if (payload.verdict === 'approved') {
 			log.info('job-completion', `review ${job.id} approved — chain complete`);
-			return;
+			// Clean up the worktree inherited from the task job
+			cleanupWorktree(job);
+			return false;
 		}
 
 		if (payload.verdict === 'changes_requested') {
@@ -123,7 +139,9 @@ function applyLoopLogic(job: Job, payload: CompletionPayload): void {
 				updateJobStatus(job.id, {
 					result_summary: (job.result_summary ?? '') + '\n[Loop cap reached — skipped automatic fix]',
 				});
-				return;
+				// Clean up the worktree — no more fixes coming
+				cleanupWorktree(job);
+				return false;
 			}
 
 			const fixJob = createJob({
@@ -142,8 +160,11 @@ function applyLoopLogic(job: Job, payload: CompletionPayload): void {
 			});
 
 			log.info('job-completion', `enqueued fix job ${fixJob.id} for review ${job.id} (loop ${nextLoopCount}/${job.max_loops})`);
+			return true;
 		}
 	}
+
+	return false;
 }
 
 // --- Session migration ---

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -92,7 +92,9 @@ export async function pollOnce(): Promise<void> {
 // --- Job dispatch ---
 
 /**
- * Set up a worktree, create a Pi session, and send the appropriate prompt.
+ * Set up a worktree (for task jobs), create a Pi session, and send the
+ * appropriate prompt. Review jobs run in the repo's main cwd — they only
+ * need to read the PR diff, not modify files.
  */
 async function dispatchJob(job: Job): Promise<void> {
 	let worktreePath: string | null = null;
@@ -104,17 +106,24 @@ async function dispatchJob(job: Job): Promise<void> {
 			throw new Error(`Repository path not found: ${repoPath}`);
 		}
 
-		// Create a worktree for isolation
-		worktreePath = createWorktree(repoPath, job);
+		let sessionCwd: string;
 
-		// Update job with worktree path and mark as running
-		updateJobStatus(job.id, {
-			status: 'running',
-			worktree_path: worktreePath,
-		});
+		if (job.type === 'review') {
+			// Reviews run in the repo's main cwd — no worktree needed
+			sessionCwd = repoPath;
+			updateJobStatus(job.id, { status: 'running' });
+		} else {
+			// Task jobs get an isolated worktree
+			worktreePath = createWorktree(repoPath, job);
+			sessionCwd = worktreePath;
+			updateJobStatus(job.id, {
+				status: 'running',
+				worktree_path: worktreePath,
+			});
+		}
 
-		// Create a Pi session in the worktree directory
-		const sessionId = await createSession(worktreePath);
+		// Create a Pi session in the appropriate directory
+		const sessionId = await createSession(sessionCwd);
 
 		// Update job with session ID
 		updateJobStatus(job.id, { session_id: sessionId });


### PR DESCRIPTION
Review jobs don't modify files — they only read the PR diff. Running them in the repo's main cwd avoids unnecessary worktree creation and the undefined session ID issue.

**Changes:**
- **Poller**: review jobs skip worktree creation, session runs in repo cwd
- **Completion**: worktree cleanup deferred through the chain — task worktree stays alive until review completes
- **Worktree path inheritance**: review jobs inherit `worktree_path` from their parent task for cleanup
- **Chain cleanup**: worktree cleaned up on review approved, loop cap reached, or chain end