### PR TITLE
fix: handle job completion server-side on agent_end

### DIFF
--- a/src/lib/server/job-poller.test.ts
+++ b/src/lib/server/job-poller.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { start, stop, isRunning } from './job-poller';
-import { createJob, getJob, getJobs } from './job-queue';
+import { start, stop, isRunning, handleJobAgentEnd } from './job-poller';
+import { createJob, getJob, getJobs, updateJobStatus } from './job-queue';
 import { getDb } from './cache';
 
 function clearJobs() {
@@ -69,6 +69,151 @@ describe('job-poller', () => {
 			const job = jobs[0];
 			expect(job.status).toBe('failed');
 			expect(job.error).toContain('not found');
+		});
+	});
+
+	describe('handleJobAgentEnd', () => {
+		it('completes a running task and enqueues a review job', () => {
+			const job = createJob({
+				type: 'task',
+				title: 'Implement widget',
+				repo: '/repo',
+				branch: 'feat/widget',
+			});
+			updateJobStatus(job.id, { status: 'running' });
+
+			const assistantText = 'Done! Created PR.\nPR_URL: https://github.com/org/repo/pull/42\n';
+			handleJobAgentEnd(job.id, assistantText);
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('done');
+			expect(updated.pr_url).toBe('https://github.com/org/repo/pull/42');
+
+			// A review job should have been enqueued
+			const allJobs = getJobs();
+			expect(allJobs).toHaveLength(2);
+
+			const reviewJob = allJobs.find((j) => j.type === 'review');
+			expect(reviewJob).toBeTruthy();
+			expect(reviewJob!.status).toBe('queued');
+			expect(reviewJob!.parent_job_id).toBe(job.id);
+			expect(reviewJob!.pr_url).toBe('https://github.com/org/repo/pull/42');
+		});
+
+		it('completes a running review with verdict and enqueues fix task', () => {
+			const taskJob = createJob({ type: 'task', title: 'Task', repo: '/repo' });
+			const reviewJob = createJob({
+				type: 'review',
+				title: 'Review: Task',
+				parent_job_id: taskJob.id,
+				repo: '/repo',
+				branch: 'feat/test',
+				loop_count: 0,
+				max_loops: 5,
+			});
+			updateJobStatus(reviewJob.id, { status: 'running' });
+
+			const assistantText = 'Found issues.\nVERDICT: changes_requested\nPlease fix the error handling.';
+			handleJobAgentEnd(reviewJob.id, assistantText);
+
+			const updated = getJob(reviewJob.id)!;
+			expect(updated.status).toBe('done');
+			expect(updated.review_verdict).toBe('changes_requested');
+
+			// A fix task should have been enqueued
+			const allJobs = getJobs();
+			expect(allJobs).toHaveLength(3);
+
+			const fixJob = allJobs.find(
+				(j) => j.type === 'task' && j.parent_job_id === reviewJob.id
+			);
+			expect(fixJob).toBeTruthy();
+			expect(fixJob!.loop_count).toBe(1);
+			expect(fixJob!.status).toBe('queued');
+		});
+
+		it('completes a review with approved verdict — no follow-up', () => {
+			const taskJob = createJob({ type: 'task', title: 'Task' });
+			const reviewJob = createJob({
+				type: 'review',
+				title: 'Review: Task',
+				parent_job_id: taskJob.id,
+			});
+			updateJobStatus(reviewJob.id, { status: 'running' });
+
+			const assistantText = 'Looks good!\nVERDICT: approved';
+			handleJobAgentEnd(reviewJob.id, assistantText);
+
+			const updated = getJob(reviewJob.id)!;
+			expect(updated.status).toBe('done');
+			expect(updated.review_verdict).toBe('approved');
+
+			// No new jobs — chain is complete
+			expect(getJobs()).toHaveLength(2);
+		});
+
+		it('is a no-op when the job is already completed (double-completion guard)', () => {
+			const job = createJob({
+				type: 'task',
+				title: 'Already done',
+				repo: '/repo',
+			});
+			updateJobStatus(job.id, { status: 'done' });
+
+			// Should not throw and should not create follow-up jobs
+			handleJobAgentEnd(job.id, 'PR_URL: https://github.com/org/repo/pull/1');
+
+			expect(getJobs()).toHaveLength(1);
+			expect(getJob(job.id)!.status).toBe('done');
+		});
+
+		it('is a no-op for an unknown job ID', () => {
+			// Should not throw
+			handleJobAgentEnd('nonexistent-id', 'some text');
+			expect(getJobs()).toHaveLength(0);
+		});
+
+		it('extracts PR_URL and VERDICT from mixed assistant text', () => {
+			const job = createJob({
+				type: 'task',
+				title: 'Mixed output test',
+				repo: '/repo',
+			});
+			updateJobStatus(job.id, { status: 'running' });
+
+			const assistantText = [
+				'Starting work on the feature...',
+				'Running tests... all pass.',
+				'Created PR at PR_URL: https://github.com/org/repo/pull/99',
+				'All done!',
+			].join('\n');
+
+			handleJobAgentEnd(job.id, assistantText);
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('done');
+			expect(updated.pr_url).toBe('https://github.com/org/repo/pull/99');
+		});
+
+		it('handles completion without any markers in the text', () => {
+			const job = createJob({
+				type: 'task',
+				title: 'No markers',
+				repo: '/repo',
+			});
+			updateJobStatus(job.id, { status: 'running' });
+
+			handleJobAgentEnd(job.id, 'Did some work but forgot to output markers.');
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('done');
+
+			// Review should still be enqueued (PR URL is optional)
+			const allJobs = getJobs();
+			expect(allJobs).toHaveLength(2);
+			const reviewJob = allJobs.find((j) => j.type === 'review');
+			expect(reviewJob).toBeTruthy();
+			expect(reviewJob!.status).toBe('queued');
 		});
 	});
 });

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -2,9 +2,10 @@
  * Background poller that claims queued jobs and dispatches them to Pi sessions.
  * Creates git worktrees for isolation and spawns sessions via rpc-manager.
  */
-import { claimNextJob, updateJobStatus, type Job } from './job-queue';
+import { claimNextJob, updateJobStatus, getJob, type Job } from './job-queue';
 import { buildTaskPrompt, buildTaskFixPrompt, buildReviewPrompt } from './job-prompts';
-import { createSession, sendMessage } from './rpc-manager';
+import { handleCompletion } from './job-completion';
+import { createSession, sendMessage, subscribe } from './rpc-manager';
 import { log } from './logger';
 import { join } from 'path';
 import { mkdirSync, existsSync, rmSync } from 'fs';
@@ -15,10 +16,17 @@ import { execFileSync } from 'child_process';
 const POLL_INTERVAL_MS = 30_000;
 const WORKTREE_BASE = process.env.PI_WORKTREE_DIR || join(process.cwd(), '.worktrees');
 
+/** Patterns for extracting result markers from assistant text. */
+const PR_URL_PATTERN = /PR_URL:\s*(\S+)/;
+const VERDICT_PATTERN = /VERDICT:\s*(approved|changes_requested)/;
+
 // --- State ---
 
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let isPolling = false;
+
+/** Active session subscriptions keyed by job ID — used to unsubscribe on cleanup. */
+const sessionUnsubscribers = new Map<string, () => void>();
 
 // --- Public API ---
 
@@ -128,6 +136,10 @@ async function dispatchJob(job: Job): Promise<void> {
 		// Update job with session ID
 		updateJobStatus(job.id, { session_id: sessionId });
 
+		// Subscribe to session events so we can detect agent_end and trigger
+		// job completion server-side — the extension callback is a fallback.
+		subscribeToJobSession(job.id, sessionId);
+
 		// Build and send the appropriate prompt
 		const prompt = buildPromptForJob(job);
 		await sendMessage(sessionId, prompt);
@@ -140,6 +152,95 @@ async function dispatchJob(job: Job): Promise<void> {
 			error: `Dispatch failed: ${err.message}`,
 			worktree_path: worktreePath ?? undefined,
 		});
+	}
+}
+
+// --- Session subscription for server-side job completion ---
+
+/**
+ * Subscribe to a job's Pi session to detect agent_end events.
+ * When the agent finishes, we extract result markers from the last assistant
+ * message and call handleCompletion directly — no reliance on the extension.
+ */
+function subscribeToJobSession(jobId: string, sessionId: string): void {
+	// Accumulated assistant text across all messages in the session
+	let fullAssistantText = '';
+
+	const unsubscribe = subscribe(sessionId, (event: any) => {
+		// Accumulate assistant text deltas so we have the full conversation
+		if (event.type === 'message_update') {
+			const ame = event.assistantMessageEvent;
+			if (ame?.type === 'text_delta') {
+				fullAssistantText += ame.delta;
+			}
+		}
+
+		if (event.type === 'agent_end') {
+			// Include any text captured in _lastAssistantText (the final message)
+			const lastText = event._lastAssistantText ?? '';
+			const combinedText = fullAssistantText + '\n' + lastText;
+
+			handleJobAgentEnd(jobId, combinedText);
+			cleanupSubscription(jobId);
+		}
+
+		if (event.type === 'session_ended') {
+			// Session ended without agent_end — treat as completion
+			handleJobAgentEnd(jobId, fullAssistantText);
+			cleanupSubscription(jobId);
+		}
+	});
+
+	sessionUnsubscribers.set(jobId, unsubscribe);
+}
+
+/**
+ * Remove the session subscription for a job.
+ */
+function cleanupSubscription(jobId: string): void {
+	const unsubscribe = sessionUnsubscribers.get(jobId);
+	if (unsubscribe) {
+		unsubscribe();
+		sessionUnsubscribers.delete(jobId);
+	}
+}
+
+/**
+ * Handle agent_end for a job session. Extracts PR_URL and VERDICT from the
+ * accumulated assistant text and calls handleCompletion.
+ *
+ * Guards against double-completion — if the extension callback already
+ * completed the job, this is a no-op.
+ */
+export function handleJobAgentEnd(jobId: string, assistantText: string): void {
+	try {
+		// Re-fetch the job to check current status — the extension callback
+		// may have already completed it.
+		const job = getJob(jobId);
+		if (!job) {
+			log.warn('job-poller', `agent_end for unknown job ${jobId}`);
+			return;
+		}
+
+		if (job.status !== 'running' && job.status !== 'claimed') {
+			log.info('job-poller', `agent_end for job ${jobId} but status is already '${job.status}' — skipping (likely handled by extension callback)`);
+			return;
+		}
+
+		// Extract result markers from assistant text
+		const prUrlMatch = assistantText.match(PR_URL_PATTERN);
+		const verdictMatch = assistantText.match(VERDICT_PATTERN);
+
+		log.info('job-poller', `agent_end for job ${jobId} — prUrl=${prUrlMatch?.[1] ?? 'none'}, verdict=${verdictMatch?.[1] ?? 'none'}`);
+
+		handleCompletion(jobId, {
+			jobId,
+			status: 'done',
+			prUrl: prUrlMatch?.[1],
+			verdict: verdictMatch?.[1] as 'approved' | 'changes_requested' | undefined,
+		});
+	} catch (err) {
+		log.error('job-poller', `failed to handle agent_end for job ${jobId}: ${err}`);
 	}
 }
 

--- a/src/lib/server/rpc-manager.ts
+++ b/src/lib/server/rpc-manager.ts
@@ -221,6 +221,9 @@ function processData(managed: ManagedSession, raw: Buffer | Uint8Array) {
 				}
 			}
 			if (parsed.type === 'agent_end') {
+				// Capture accumulated text before clearing — subscribers may need it
+				// (e.g. job-poller extracting PR_URL / VERDICT from the final message)
+				parsed._lastAssistantText = managed.streamingAssistantText;
 				managed.isStreaming = false;
 				managed.lastAgentStartTime = null;
 				managed.streamingAssistantText = '';


### PR DESCRIPTION
## Problem

Reviews were not being added to the queue after task work completed. The job queue relied entirely on the Pi extension (`job-callback.ts`) to POST back to the server when a task/review finished. If the extension didn't fire (e.g. not loaded, markers compacted away, POST failed), the job stayed stuck in `running` status and no review was ever enqueued.

## Solution

Added server-side `agent_end` detection in the job-poller. When a job's Pi session finishes:

1. **rpc-manager** now attaches `_lastAssistantText` to `agent_end` events before clearing the streaming buffer, so subscribers can access the final message text
2. **job-poller** subscribes to each dispatched session and accumulates assistant text deltas across the full conversation
3. On `agent_end`, the poller extracts `PR_URL` and `VERDICT` markers from the accumulated text and calls `handleCompletion` directly
4. A double-completion guard ensures if the extension callback fires too (race condition), the second call is a safe no-op

The extension callback remains as a fallback mechanism.

## Tests

7 new tests covering:
- Server-side task completion → review enqueue
- Review with `changes_requested` → fix task enqueue  
- Review with `approved` → chain complete
- Double-completion guard (no-op on already-completed job)
- Unknown job ID handling
- Marker extraction from mixed text
- Completion without markers (review still enqueued)