### PR TITLE
docs: add sample pi config for autonomous job workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,27 @@ bun run package
 ./dist/pi-dashboard
 ```
 
+## Job Queue & Autonomous Workflow
+
+pi-remote-web includes a job queue that dispatches tasks to Pi sessions and
+runs an autonomous **task → review → fix** loop until the work is approved.
+
+See [`sample-pi-config/`](sample-pi-config/) for the Pi configuration files
+(AGENTS.md, review skill, extension) that make this workflow tick. Copy and
+adapt them to your own projects.
+
+### Quick Setup
+
+```sh
+# Install the job callback extension (symlinks into ~/.pi/agent/extensions/)
+./scripts/setup-hooks.sh
+
+# Copy the sample review skill
+cp -r sample-pi-config/skills/review ~/.pi/agent/skills/review
+```
+
+Then create jobs via the dashboard or the API — the poller handles the rest.
+
 ## Project Structure
 
 ```

--- a/sample-pi-config/AGENTS.md
+++ b/sample-pi-config/AGENTS.md
@@ -1,0 +1,39 @@
+# Project Guidelines
+
+Sample `.pi/agent/AGENTS.md` — place in your home directory or project root.
+This file is loaded by Pi as context for every session, teaching the agent
+your team's conventions and workflow expectations.
+
+## Code Style
+
+- Follow existing project conventions
+- Use meaningful variable names
+- Keep functions under 50 lines
+- Add comments for complex logic only
+- DRY — extract shared logic into reusable functions, modules, or constants
+- No magic numbers — define all numeric literals as named constants with clear intent
+
+## Git
+
+- Conventional Commits: `feat`/`fix`/`refactor`/`docs`/`test`/`chore`
+- Atomic commits, one concern per commit
+- Never force push to main
+- Never commit directly to main — always create a feature branch first
+- Auto-commit and push to feature branches without asking
+
+## Safety
+
+- Never hardcode secrets or API keys
+- Always validate user input
+- Handle errors explicitly, no silent failures
+
+## Testing
+
+- Always write tests for new work (features, bug fixes, refactors)
+- Run tests to verify they pass before committing
+
+## Workflow
+
+- Read before write — understand context first
+- Minimal changes — don't refactor unrelated code
+- Verify after changes — run tests or check output

--- a/sample-pi-config/README.md
+++ b/sample-pi-config/README.md
@@ -1,0 +1,130 @@
+# Sample Pi Configuration
+
+These files demonstrate the configuration that makes pi-remote-web's autonomous
+job workflow tick. Copy and adapt them to your own projects.
+
+## What's Here
+
+```
+sample-pi-config/
+├── README.md                   # This file
+├── AGENTS.md                   # Project guidelines for the agent
+└── skills/
+    └── review/
+        └── SKILL.md            # Code review skill with verdict output
+```
+
+## How the Pieces Fit Together
+
+pi-remote-web's job queue dispatches tasks to Pi sessions and uses a
+**task → review → fix** loop to iterate until the work is approved (or a loop
+cap is reached). Three pieces of configuration make this possible:
+
+### 1. AGENTS.md — Project Guidelines
+
+Place at `~/.pi/agent/AGENTS.md` (global) or `.pi/agent/AGENTS.md` (per-project).
+
+This teaches the agent your team's conventions: commit style, branching rules,
+testing expectations, and code standards. Every Pi session loads it
+automatically — both interactive sessions and autonomous jobs benefit.
+
+### 2. Review Skill — Structured Code Review
+
+Place under `~/.pi/agent/skills/review/SKILL.md` or `.pi/skills/review/SKILL.md`.
+
+The review skill gives the agent a structured process for reviewing pull
+requests. It checks correctness, test coverage, code style, security, and
+performance, then outputs a machine-readable verdict:
+
+```
+VERDICT: approved
+```
+or
+```
+VERDICT: changes_requested
+```
+
+pi-remote-web's job system parses this verdict to decide whether to enqueue a
+fix job or mark the chain as complete. The review skill is referenced via the
+`review_skill` field when creating a job through the API or dashboard.
+
+### 3. Job Callback Extension
+
+The extension at `extensions/job-callback.ts` (in the pi-remote-web repo) is a
+Pi extension that fires on `agent_end`. It scans the conversation for job
+metadata markers (`JOB_ID`, `CALLBACK_URL`, `CALLBACK_TOKEN`) and result
+markers (`PR_URL`, `VERDICT`), then POSTs the results back to pi-remote-web.
+
+Install it with:
+
+```bash
+./scripts/setup-hooks.sh
+```
+
+This symlinks the extension into `~/.pi/agent/extensions/` so it's active for
+all Pi sessions.
+
+## Setting Up a Project
+
+1. **Copy `AGENTS.md`** to your project's `.pi/agent/AGENTS.md` and customise
+   the guidelines for your team's conventions.
+
+2. **Copy the review skill** to `~/.pi/agent/skills/review/` (global) or
+   `.pi/skills/review/` (per-project).
+
+3. **Install the job callback extension** by running
+   `./scripts/setup-hooks.sh` from the pi-remote-web repo.
+
+4. **Create a job** via the pi-remote-web dashboard or API:
+
+   ```bash
+   curl -X POST http://localhost:4020/api/jobs \
+     -H 'Content-Type: application/json' \
+     -d '{
+       "type": "task",
+       "title": "Add input validation to signup form",
+       "repo": "/path/to/your/project",
+       "target_branch": "main",
+       "review_skill": "review"
+     }'
+   ```
+
+   The job poller will claim it, create a git worktree, spawn a Pi session,
+   and start the autonomous loop.
+
+## Customising the Review Skill
+
+The sample review skill is intentionally generic. You can customise it for your
+project by:
+
+- Adding project-specific review criteria (e.g. "check for Australian English
+  spelling" or "verify all API endpoints have rate limiting")
+- Referencing project documentation or style guides
+- Adjusting the review process to match your team's workflow
+- Adding domain-specific checks (e.g. "verify database migrations are
+  reversible")
+
+## How the Loop Works
+
+```
+┌─────────────────────────────────────────────┐
+│                                             │
+│  1. Job queued (type: task)                 │
+│  2. Poller claims job, creates worktree     │
+│  3. Pi session implements the task          │
+│  4. Agent creates PR, outputs PR_URL        │
+│  5. Callback fires → review job enqueued    │
+│                                             │
+│  6. Review job claimed                      │
+│  7. Pi session reviews the PR               │
+│  8. Agent outputs VERDICT                   │
+│     ├─ approved → chain complete ✓          │
+│     └─ changes_requested → fix job enqueued │
+│                                             │
+│  9. Fix job claimed (loop_count++)          │
+│ 10. Pi session addresses review feedback    │
+│ 11. Back to step 5 (until approved or       │
+│     loop cap reached)                       │
+│                                             │
+└─────────────────────────────────────────────┘
+```

--- a/sample-pi-config/skills/review/SKILL.md
+++ b/sample-pi-config/skills/review/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: review
+description: >-
+  Code review skill for pull requests. Use when reviewing PRs, checking code
+  quality, verifying test coverage, and providing structured feedback. Outputs
+  a VERDICT of approved or changes_requested.
+---
+
+# Code Review
+
+Review a pull request thoroughly, then output a final verdict.
+
+## Process
+
+1. **Read the PR diff** using `gh pr diff <pr-url>` or by examining the changed files
+2. **Check out the branch** if you need to run tests or typecheck locally
+3. **Review each file** for the criteria below
+4. **Summarise findings** with specific file and line references
+5. **Output your verdict** — see [Verdict Format](#verdict-format)
+
+## Review Criteria
+
+### Correctness
+- Logic errors, off-by-one mistakes, race conditions
+- Edge cases not handled
+- Incorrect assumptions about data shape or API contracts
+
+### Test Coverage
+- New code should have corresponding tests
+- Tests should cover happy path and error cases
+- Run the test suite: check for failures or missing coverage
+
+### Code Style & Conventions
+- Follows the project's existing patterns and naming conventions
+- No unnecessary complexity or premature abstractions
+- Functions are focused and reasonably sized
+- No duplicated logic that should be extracted
+
+### Security
+- No hardcoded secrets, tokens, or credentials
+- User input is validated and sanitised
+- No SQL injection, XSS, or path traversal vulnerabilities
+
+### Performance
+- No obviously inefficient algorithms (e.g. N+1 queries, unbounded loops)
+- Large data sets handled with pagination or streaming
+- No unnecessary blocking operations on the main thread
+
+## Verdict Format
+
+After completing your review, output exactly one of the following on its own line:
+
+```
+VERDICT: approved
+```
+
+```
+VERDICT: changes_requested
+```
+
+If changes are requested, provide **specific, actionable feedback** above the
+verdict explaining what needs to be fixed. Reference file paths and line numbers
+where possible.
+
+## Submitting the Review
+
+Use the GitHub CLI to submit your review:
+
+```bash
+# Approve
+gh pr review <pr-url> --approve --body "Looks good — all checks pass."
+
+# Request changes
+gh pr review <pr-url> --request-changes --body "<your detailed feedback>"
+```


### PR DESCRIPTION
Adds a `sample-pi-config/` directory with the configuration files that make the autonomous task → review → fix loop work:

- **`AGENTS.md`** — project guidelines template that teaches the agent team conventions (commit style, branching, testing, code standards)
- **`skills/review/SKILL.md`** — structured code review skill with machine-readable `VERDICT: approved` / `VERDICT: changes_requested` output that pi-remote-web parses to drive the loop
- **`README.md`** — explains how the three pieces (AGENTS.md, review skill, job callback extension) fit together, how to set up a project, and includes an ASCII diagram of the loop flow

Also updates the main README with a new "Job Queue & Autonomous Workflow" section that references the sample config and provides quick setup instructions.

All files are generic — no proprietary system references.