### PR TITLE
fix: treat timezone-less timestamps as UTC in timeAgo

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -51,6 +51,33 @@ describe('timeAgo', () => {
 		Date.now = () => new Date('2025-01-16T12:00:00Z').getTime();
 		expect(timeAgo('2025-01-15T12:00:00Z')).toBe('1d ago');
 	});
+
+	// SQLite datetime('now') returns UTC timestamps without a 'Z' suffix
+	it('handles SQLite datetime format without timezone suffix', () => {
+		Date.now = () => new Date('2025-01-15T15:00:00Z').getTime();
+		expect(timeAgo('2025-01-15 12:00:00')).toBe('3h ago');
+	});
+
+	it('handles SQLite datetime format for minutes', () => {
+		Date.now = () => new Date('2025-01-15T12:05:00Z').getTime();
+		expect(timeAgo('2025-01-15 12:00:00')).toBe('5m ago');
+	});
+
+	it('handles SQLite datetime format for days', () => {
+		Date.now = () => new Date('2025-01-18T12:00:00Z').getTime();
+		expect(timeAgo('2025-01-15 12:00:00')).toBe('3d ago');
+	});
+
+	it('handles timestamps with explicit positive offset', () => {
+		Date.now = () => new Date('2025-01-15T15:00:00Z').getTime();
+		// 17:00:00+02:00 = 15:00:00Z, so diff is 0 seconds = just now
+		expect(timeAgo('2025-01-15T17:00:00+02:00')).toBe('just now');
+	});
+
+	it('preserves existing Z suffix without doubling', () => {
+		Date.now = () => new Date('2025-01-15T12:05:00Z').getTime();
+		expect(timeAgo('2025-01-15T12:00:00Z')).toBe('5m ago');
+	});
 });
 
 describe('truncatePath', () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,12 @@
 export function timeAgo(dateStr: string): string {
-	const date = new Date(dateStr);
+	// SQLite's datetime('now') returns UTC timestamps without a timezone
+	// suffix (e.g. "2025-01-15 12:00:00"). Without a 'Z' or offset,
+	// JavaScript's Date constructor treats these as local time, causing
+	// the displayed time to be off by the local UTC offset.
+	// Append 'Z' when no timezone indicator is present so they're
+	// correctly parsed as UTC.
+	const normalised = /[Z+\-]\d{0,4}:?\d{0,2}$/.test(dateStr) ? dateStr : dateStr + 'Z';
+	const date = new Date(normalised);
 	const now = Date.now();
 	const diff = now - date.getTime();
 	const seconds = Math.floor(diff / 1000);


### PR DESCRIPTION
SQLite's datetime('now') returns UTC timestamps without a 'Z' suffix
(e.g. '2025-01-15 12:00:00'). JavaScript's Date constructor interprets
these as local time, causing the 'hours ago' display in the jobs list
to be off by the local UTC offset (e.g. 10h in AEST).

Append 'Z' to timestamps that lack a timezone indicator so they're
correctly parsed as UTC.
