### PR TITLE
fix: add SSE-based job reactivity and debounce dashboard refreshes

### DIFF
--- a/src/lib/server/job-events.test.ts
+++ b/src/lib/server/job-events.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect, mock } from 'bun:test';
+import { emitJobEvent, onJobEvent, type JobEvent } from './job-events';
+
+describe('job-events', () => {
+	test('subscriber receives emitted events', () => {
+		const received: JobEvent[] = [];
+		const unsubscribe = onJobEvent((event) => received.push(event));
+
+		emitJobEvent({ type: 'job_created', jobId: 'test-1', status: 'queued' });
+		emitJobEvent({ type: 'job_updated', jobId: 'test-1', status: 'running' });
+
+		expect(received).toEqual([
+			{ type: 'job_created', jobId: 'test-1', status: 'queued' },
+			{ type: 'job_updated', jobId: 'test-1', status: 'running' },
+		]);
+
+		unsubscribe();
+	});
+
+	test('unsubscribed callback no longer receives events', () => {
+		const received: JobEvent[] = [];
+		const unsubscribe = onJobEvent((event) => received.push(event));
+
+		emitJobEvent({ type: 'job_created', jobId: 'test-2', status: 'queued' });
+		unsubscribe();
+		emitJobEvent({ type: 'job_updated', jobId: 'test-2', status: 'running' });
+
+		expect(received).toEqual([
+			{ type: 'job_created', jobId: 'test-2', status: 'queued' },
+		]);
+	});
+
+	test('multiple subscribers all receive events', () => {
+		const received1: JobEvent[] = [];
+		const received2: JobEvent[] = [];
+		const unsub1 = onJobEvent((event) => received1.push(event));
+		const unsub2 = onJobEvent((event) => received2.push(event));
+
+		emitJobEvent({ type: 'job_deleted', jobId: 'test-3' });
+
+		expect(received1).toEqual([{ type: 'job_deleted', jobId: 'test-3' }]);
+		expect(received2).toEqual([{ type: 'job_deleted', jobId: 'test-3' }]);
+
+		unsub1();
+		unsub2();
+	});
+
+	test('emitting with no subscribers does not throw', () => {
+		expect(() => {
+			emitJobEvent({ type: 'job_created', jobId: 'test-4', status: 'queued' });
+		}).not.toThrow();
+	});
+});

--- a/src/lib/server/job-events.ts
+++ b/src/lib/server/job-events.ts
@@ -1,0 +1,31 @@
+/**
+ * Job event bus — emits events when job status changes.
+ * Subscribers (e.g. SSE endpoints) receive notifications to push updates to clients.
+ */
+
+export type JobEventType = 'job_updated' | 'job_created' | 'job_deleted';
+
+export interface JobEvent {
+	type: JobEventType;
+	jobId: string;
+	status?: string;
+}
+
+const callbacks = new Set<(event: JobEvent) => void>();
+
+/**
+ * Emit a job event to all subscribers.
+ */
+export function emitJobEvent(event: JobEvent): void {
+	for (const cb of callbacks) {
+		cb(event);
+	}
+}
+
+/**
+ * Subscribe to job events. Returns an unsubscribe function.
+ */
+export function onJobEvent(callback: (event: JobEvent) => void): () => void {
+	callbacks.add(callback);
+	return () => callbacks.delete(callback);
+}

--- a/src/lib/server/job-queue.ts
+++ b/src/lib/server/job-queue.ts
@@ -4,6 +4,7 @@
  */
 import { getDb } from './cache';
 import { log } from './logger';
+import { emitJobEvent } from './job-events';
 
 // --- Types ---
 
@@ -129,6 +130,7 @@ export function createJob(input: CreateJobInput): Job {
 	}) as Job;
 
 	log.info('job-queue', `created job ${row.id} (${row.type ?? 'task'}): ${row.title}`);
+	emitJobEvent({ type: 'job_created', jobId: row.id, status: row.status });
 	return row;
 }
 
@@ -140,6 +142,7 @@ export function claimNextJob(): Job | null {
 	const row = claimQuery().get() as Job | null;
 	if (row) {
 		log.info('job-queue', `claimed job ${row.id} (${row.type}): ${row.title}`);
+		emitJobEvent({ type: 'job_updated', jobId: row.id, status: row.status });
 	}
 	return row;
 }
@@ -177,6 +180,7 @@ export function updateJobStatus(id: string, updates: UpdateJobInput): Job | null
 
 	if (row) {
 		log.info('job-queue', `updated job ${id}: status=${row.status}`);
+		emitJobEvent({ type: 'job_updated', jobId: id, status: row.status });
 	}
 	return row;
 }
@@ -256,6 +260,7 @@ export function deleteJob(id: string): Job | null {
 	const deleted = deleteJobQuery().get(id) as Job | null;
 	if (deleted) {
 		log.info('job-queue', `deleted job ${id}`);
+		emitJobEvent({ type: 'job_deleted', jobId: id });
 	}
 	return deleted;
 }
@@ -284,6 +289,7 @@ export function retryJob(id: string): Job | null {
 
 	if (row) {
 		log.info('job-queue', `retried job ${id} (attempt ${row.retry_count}/${row.max_retries})`);
+		emitJobEvent({ type: 'job_updated', jobId: id, status: row.status });
 	}
 	return row;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -296,11 +296,26 @@
 		}
 	}
 
-	// Auto-refresh via SSE
+	// Auto-refresh via SSE (sessions + job events are both emitted on this endpoint)
 	$effect(() => {
+		let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+		const DEBOUNCE_MS = 500;
+
+		function debouncedRefresh() {
+			if (debounceTimer) clearTimeout(debounceTimer);
+			debounceTimer = setTimeout(() => {
+				debounceTimer = null;
+				invalidateAll();
+			}, DEBOUNCE_MS);
+		}
+
 		const es = new EventSource('/api/sessions/watch');
-		es.onmessage = () => invalidateAll();
-		return () => es.close();
+		es.onmessage = () => debouncedRefresh();
+
+		return () => {
+			if (debounceTimer) clearTimeout(debounceTimer);
+			es.close();
+		};
 	});
 </script>
 

--- a/src/routes/api/sessions/watch/+server.ts
+++ b/src/routes/api/sessions/watch/+server.ts
@@ -1,4 +1,5 @@
 import { onSessionsChanged } from '$lib/server/session-watcher';
+import { onJobEvent } from '$lib/server/job-events';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = ({ request }) => {
@@ -6,9 +7,17 @@ export const GET: RequestHandler = ({ request }) => {
 		start(controller) {
 			const encoder = new TextEncoder();
 
-			const unsubscribe = onSessionsChanged(() => {
+			const unsubscribeSessions = onSessionsChanged(() => {
 				try {
 					controller.enqueue(encoder.encode(`data: {"type":"sessions_changed"}\n\n`));
+				} catch {
+					/* stream closed */
+				}
+			});
+
+			const unsubscribeJobs = onJobEvent((event) => {
+				try {
+					controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
 				} catch {
 					/* stream closed */
 				}
@@ -23,7 +32,8 @@ export const GET: RequestHandler = ({ request }) => {
 			}, 30000);
 
 			request.signal.addEventListener('abort', () => {
-				unsubscribe();
+				unsubscribeSessions();
+				unsubscribeJobs();
 				clearInterval(heartbeat);
 				try {
 					controller.close();

--- a/src/routes/jobs/+page.svelte
+++ b/src/routes/jobs/+page.svelte
@@ -211,17 +211,26 @@
 		}
 	}
 
-	// Auto-refresh via SSE
+	// Auto-refresh via SSE (sessions + job events are both emitted on this endpoint)
 	$effect(() => {
-		const es = new EventSource('/api/sessions/watch');
-		es.onmessage = () => invalidateAll();
-		return () => es.close();
-	});
+		let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+		const DEBOUNCE_MS = 500;
 
-	// Periodic refresh for job status changes (jobs don't go through SSE)
-	$effect(() => {
-		const interval = setInterval(() => invalidateAll(), 5000);
-		return () => clearInterval(interval);
+		function debouncedRefresh() {
+			if (debounceTimer) clearTimeout(debounceTimer);
+			debounceTimer = setTimeout(() => {
+				debounceTimer = null;
+				invalidateAll();
+			}, DEBOUNCE_MS);
+		}
+
+		const es = new EventSource('/api/sessions/watch');
+		es.onmessage = () => debouncedRefresh();
+
+		return () => {
+			if (debounceTimer) clearTimeout(debounceTimer);
+			es.close();
+		};
 	});
 </script>
 


### PR DESCRIPTION
- Add job event bus (job-events.ts) that emits events on job create,
  update, claim, delete, and retry
- Wire job events into the sessions/watch SSE endpoint so clients
  receive real-time job status notifications
- Replace 5-second polling on jobs page with SSE-based reactivity
- Debounce SSE-triggered invalidateAll() calls (500ms) on both
  dashboard and jobs page to prevent rapid re-renders that could
  disrupt open dialogs
- Add tests for the job event bus
