### PR TITLE
fix: slash command autocomplete timing and reliability

### DIFF
--- a/src/lib/components/MessageInput.svelte
+++ b/src/lib/components/MessageInput.svelte
@@ -60,9 +60,14 @@
 	let commands = $state<SlashCommand[]>([]);
 	let commandsLoadedForSession = $state<string | null>(null);
 	let commandsFetching = $state(false);
+	let commandsRetryCount = $state(0);
 	let showAutocomplete = $state(false);
 	let selectedIndex = $state(0);
 	let menuRef: HTMLUListElement | undefined = $state();
+
+	const COMMANDS_FETCH_TIMEOUT_MS = 5_000; // short timeout — metadata query, not a long operation
+	const COMMANDS_RETRY_DELAY_MS = 1_500; // auto-retry delay when session wasn't ready
+	const MAX_COMMANDS_RETRIES = 3;
 
 	const filtered = $derived.by(() => {
 		if (!showAutocomplete) return [];
@@ -76,6 +81,7 @@
 		const _id = sessionId;
 		commandsLoadedForSession = null;
 		commands = [];
+		commandsRetryCount = 0;
 	});
 
 	// Fetch commands lazily on first /
@@ -85,17 +91,32 @@
 		if (commandsLoadedForSession === sessionId && commands.length > 0) return;
 		commandsFetching = true;
 		try {
-			const res = await fetch(`/api/sessions/${sessionId}/commands`);
+			const controller = new AbortController();
+			const timeoutId = setTimeout(() => controller.abort(), COMMANDS_FETCH_TIMEOUT_MS);
+			const res = await fetch(`/api/sessions/${sessionId}/commands`, { signal: controller.signal });
+			clearTimeout(timeoutId);
 			if (res.ok) {
 				const data = await res.json();
-				commands = Array.isArray(data.commands) ? data.commands : [];
-				// Only mark as loaded if we got commands — allows retry when session wasn't ready
-				if (commands.length > 0) {
+				const fetched = Array.isArray(data.commands) ? data.commands : [];
+				commands = fetched;
+				if (fetched.length > 0) {
 					commandsLoadedForSession = sessionId;
+					commandsRetryCount = 0;
+					// Refresh autocomplete now that commands arrived
+					updateAutocomplete();
+				} else if (commandsRetryCount < MAX_COMMANDS_RETRIES) {
+					// Session may not be ready — schedule an automatic retry
+					commandsRetryCount++;
+					setTimeout(() => {
+						// Only retry if still on the same session and still no commands
+						if (commandsLoadedForSession !== sessionId) {
+							ensureCommands();
+						}
+					}, COMMANDS_RETRY_DELAY_MS);
 				}
 			}
 		} catch {
-			/* ignore — will retry on next / keystroke */
+			/* ignore — will retry on next / keystroke or via auto-retry */
 		} finally {
 			commandsFetching = false;
 		}
@@ -550,13 +571,17 @@
 		}
 	}
 
-	async function handleInput() {
+	function handleInput() {
 		// Clear error when user starts typing again
 		if (sendError) sendError = null;
-		if (message.startsWith('/')) {
-			await ensureCommands();
-		}
+		// Update autocomplete state synchronously so the dropdown appears instantly
+		// when commands are already cached
 		updateAutocomplete();
+		// Fire-and-forget: fetch commands in the background if needed.
+		// When they arrive, ensureCommands calls updateAutocomplete() again.
+		if (message.startsWith('/')) {
+			ensureCommands();
+		}
 	}
 
 	function scrollSelectedIntoView() {

--- a/src/lib/server/commands.test.ts
+++ b/src/lib/server/commands.test.ts
@@ -23,6 +23,27 @@ function normaliseClientResponse(data: any): any[] {
 	return Array.isArray(data.commands) ? data.commands : [];
 }
 
+/**
+ * Simulates the autocomplete visibility logic from MessageInput.svelte.
+ * Returns true when the dropdown should be visible.
+ */
+function shouldShowAutocomplete(message: string): boolean {
+	return message.startsWith('/') && !message.includes(' ') && message.length >= 1;
+}
+
+/**
+ * Simulates the filtered commands derivation from MessageInput.svelte.
+ */
+function filterCommands(
+	showAutocomplete: boolean,
+	message: string,
+	commands: Array<{ name: string }>
+): Array<{ name: string }> {
+	if (!showAutocomplete) return [];
+	const input = message.slice(1).toLowerCase();
+	return commands.filter((c) => c.name.toLowerCase().startsWith(input));
+}
+
 describe('commands API normalisation', () => {
 	describe('server-side (RPC result → response)', () => {
 		it('handles an array result directly', () => {
@@ -141,6 +162,86 @@ describe('commands API normalisation', () => {
 
 		it('returns empty array for unexpected RPC result', () => {
 			expect(roundTrip('error')).toEqual([]);
+		});
+	});
+
+	describe('autocomplete visibility logic', () => {
+		it('shows autocomplete for bare slash', () => {
+			expect(shouldShowAutocomplete('/')).toBe(true);
+		});
+
+		it('shows autocomplete for partial command', () => {
+			expect(shouldShowAutocomplete('/pl')).toBe(true);
+		});
+
+		it('shows autocomplete for full command without space', () => {
+			expect(shouldShowAutocomplete('/plan')).toBe(true);
+		});
+
+		it('hides autocomplete after space (command accepted)', () => {
+			expect(shouldShowAutocomplete('/plan ')).toBe(false);
+		});
+
+		it('hides autocomplete for command with arguments', () => {
+			expect(shouldShowAutocomplete('/plan something')).toBe(false);
+		});
+
+		it('hides autocomplete for empty message', () => {
+			expect(shouldShowAutocomplete('')).toBe(false);
+		});
+
+		it('hides autocomplete for non-slash message', () => {
+			expect(shouldShowAutocomplete('hello')).toBe(false);
+		});
+
+		it('hides autocomplete for message with slash mid-text', () => {
+			expect(shouldShowAutocomplete('hello /plan')).toBe(false);
+		});
+	});
+
+	describe('command filtering', () => {
+		const commands = [
+			{ name: 'plan' },
+			{ name: 'compact' },
+			{ name: 'help' },
+			{ name: 'prompt' },
+		];
+
+		it('returns all commands for bare slash', () => {
+			const result = filterCommands(true, '/', commands);
+			expect(result).toHaveLength(4);
+		});
+
+		it('filters by prefix', () => {
+			const result = filterCommands(true, '/p', commands);
+			expect(result).toHaveLength(2);
+			expect(result.map(c => c.name)).toEqual(['plan', 'prompt']);
+		});
+
+		it('filters case-insensitively', () => {
+			const result = filterCommands(true, '/P', commands);
+			expect(result).toHaveLength(2);
+		});
+
+		it('returns empty when no match', () => {
+			const result = filterCommands(true, '/xyz', commands);
+			expect(result).toHaveLength(0);
+		});
+
+		it('returns empty when autocomplete is hidden', () => {
+			const result = filterCommands(false, '/', commands);
+			expect(result).toHaveLength(0);
+		});
+
+		it('returns empty when commands list is empty', () => {
+			const result = filterCommands(true, '/', []);
+			expect(result).toHaveLength(0);
+		});
+
+		it('matches exact command name', () => {
+			const result = filterCommands(true, '/plan', commands);
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('plan');
 		});
 	});
 });

--- a/src/lib/server/rpc-manager.ts
+++ b/src/lib/server/rpc-manager.ts
@@ -47,6 +47,7 @@ interface ActiveSessionRow {
 
 const MAX_STREAMING_TEXT = 100 * 1024;
 const COMMAND_TIMEOUT_MS = 30_000;
+const COMMANDS_QUERY_TIMEOUT_MS = 5_000; // shorter timeout for metadata queries like get_commands
 const STATE_CHECK_TIMEOUT_MS = 5_000; // shorter timeout for pre-send state checks
 // prompt responds immediately in pi's RPC mode (fire-and-forget), so use a
 // shorter timeout. If the command doesn't reach pi within 10s something is wrong.
@@ -669,7 +670,7 @@ export async function getSessionStats(sessionId: string): Promise<any> {
 export async function getCommands(sessionId: string): Promise<any> {
 	const managed = activeSessions.get(sessionId);
 	if (!managed) throw new Error('Session not active');
-	return sendCommand(managed, { type: 'get_commands' });
+	return sendCommand(managed, { type: 'get_commands' }, COMMANDS_QUERY_TIMEOUT_MS);
 }
 
 // --- Relay lifecycle helpers ---


### PR DESCRIPTION
## Problem

Slash commands still weren't autocompleting reliably despite the fixes in #25. Three root causes remained:

### 1. Async `handleInput` blocked autocomplete rendering

`handleInput` was `async` and awaited `ensureCommands()` before calling `updateAutocomplete()`. This meant:
- On the first `/` keystroke, the dropdown only appeared after the fetch completed
- For subsequent keystrokes while a fetch was in-flight, `ensureCommands()` returned immediately (due to the `commandsFetching` guard), and `updateAutocomplete()` ran with an empty commands list — showing nothing

### 2. 30-second RPC timeout for metadata query

`get_commands` used the default 30s `COMMAND_TIMEOUT_MS`. If the agent was busy streaming, the RPC would queue behind the current operation and the fetch would hang for up to 30s with `commandsFetching = true`, blocking all retry attempts.

### 3. No automatic retry when session wasn't ready

When the session returned empty commands (e.g. still warming up), there was no automatic retry — the user had to delete and retype `/` to trigger another fetch.

## Solution

- **Synchronous `handleInput`** — `updateAutocomplete()` now runs instantly so the dropdown appears immediately when commands are cached. `ensureCommands()` fires as background fire-and-forget with a callback to `updateAutocomplete()` when commands arrive.

- **5s fetch timeout** — added `AbortController` on the client-side fetch and reduced the server-side `get_commands` RPC timeout from 30s to 5s (`COMMANDS_QUERY_TIMEOUT_MS`). This is a metadata query, not a long-running operation.

- **Automatic retry** — when the session returns empty commands, schedules up to 3 retries at 1.5s intervals. Retry count resets on session change.

## Tests

15 new tests covering autocomplete visibility logic and command filtering (263 total, all passing). Zero typecheck errors.