### PR TITLE
fix: extension callback delegates to state machine, respects review loop

### DIFF
--- a/src/lib/server/job-completion.test.ts
+++ b/src/lib/server/job-completion.test.ts
@@ -20,17 +20,17 @@ describe('job-completion', () => {
 		});
 
 		it('ignores completion for job already in terminal state', () => {
-			const job = createJob({ type: 'task', title: 'Queued job' });
+			const job = createJob({ title: 'Done job' });
 			updateJobStatus(job.id, { status: 'done' });
 
 			const result = handleCompletion(job.id, { jobId: job.id, status: 'done' });
-			
+
 			// Should return the job as-is without error
 			expect(result.status).toBe('done');
 		});
 
-		it('marks a failed job and cleans up', () => {
-			const job = createJob({ type: 'task', title: 'Failing task' });
+		it('marks a failed job directly', () => {
+			const job = createJob({ title: 'Failing task' });
 			updateJobStatus(job.id, { status: 'running' });
 
 			const result = handleCompletion(job.id, {
@@ -41,33 +41,52 @@ describe('job-completion', () => {
 
 			expect(result.status).toBe('failed');
 			expect(result.error).toBe('Something went wrong');
-
-			// No follow-up jobs created in new model
-			const allJobs = getJobs();
-			expect(allJobs).toHaveLength(1);
 		});
 
-		it('marks a job as done (simple completion - loop logic is in poller now)', () => {
-			const job = createJob({
-				type: 'task',
-				title: 'Implement feature',
-				repo: '/repo',
-				branch: 'feat/test',
-			});
+		it('delegates to state machine — running job transitions to reviewing', async () => {
+			const job = createJob({ title: 'Task with review', max_loops: 5 });
 			updateJobStatus(job.id, { status: 'running' });
 
-			const result = handleCompletion(job.id, {
+			handleCompletion(job.id, {
 				jobId: job.id,
 				status: 'done',
 				prUrl: 'https://github.com/org/repo/pull/1',
 			});
 
-			expect(result.status).toBe('done');
-			expect(result.pr_url).toBe('https://github.com/org/repo/pull/1');
+			const updated = getJob(job.id)!;
+			// State machine transitions running → reviewing (not straight to done)
+			expect(updated.status).toBe('reviewing');
+			expect(updated.pr_url).toBe('https://github.com/org/repo/pull/1');
+		});
 
-			// In the new model, handleCompletion doesn't create follow-up jobs
-			const allJobs = getJobs();
-			expect(allJobs).toHaveLength(1);
+		it('delegates to state machine — fire-and-forget goes straight to done', async () => {
+			const job = createJob({ title: 'Quick task', max_loops: 0 });
+			updateJobStatus(job.id, { status: 'running' });
+
+			handleCompletion(job.id, {
+				jobId: job.id,
+				status: 'done',
+				prUrl: 'https://github.com/org/repo/pull/2',
+			});
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('done');
+			expect(updated.pr_url).toBe('https://github.com/org/repo/pull/2');
+		});
+
+		it('delegates to state machine — review with approved verdict marks done', async () => {
+			const job = createJob({ title: 'Reviewed task', max_loops: 5 });
+			updateJobStatus(job.id, { status: 'reviewing' });
+
+			handleCompletion(job.id, {
+				jobId: job.id,
+				status: 'done',
+				verdict: 'approved',
+			});
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('done');
+			expect(updated.review_verdict).toBe('approved');
 		});
 	});
 

--- a/src/lib/server/job-completion.ts
+++ b/src/lib/server/job-completion.ts
@@ -1,6 +1,9 @@
 /**
  * Job completion handler — provides cleanup utilities for worktree and session migration.
- * The main completion logic is now in job-poller.ts (handleJobAgentEnd).
+ * The main completion logic (state machine) is in job-poller.ts (handleJobAgentEnd).
+ *
+ * The extension callback delegates to handleJobAgentEnd so the review loop
+ * is respected — it never directly marks a job as done.
  */
 import { getJob, updateJobStatus, type Job } from './job-queue';
 import { log } from './logger';
@@ -23,11 +26,17 @@ export interface CompletionPayload {
 // --- Main handler ---
 
 /**
- * Handle job completion callback from the extension (fallback).
- * In the new single-job model, this is only used as a fallback — the primary
- * completion path is through handleJobAgentEnd in job-poller.ts.
+ * Handle job completion callback from the extension.
+ * Delegates to the poller's state machine so the review loop is respected.
+ *
+ * For failures, marks the job as failed directly (no state machine needed).
+ * For success, constructs the assistant text markers and lets handleJobAgentEnd
+ * drive the state transitions (running → reviewing → done).
  */
 export function handleCompletion(jobId: string, payload: CompletionPayload): Job {
+	// Lazy import to avoid circular dependency — job-poller imports from us
+	const { handleJobAgentEnd } = require('./job-poller');
+
 	const job = getJob(jobId);
 	if (!job) {
 		throw new Error(`Job not found: ${jobId}`);
@@ -39,42 +48,37 @@ export function handleCompletion(jobId: string, payload: CompletionPayload): Job
 		return job;
 	}
 
-	// Handle failure
+	// Handle failure directly — no state machine needed
 	if (payload.status === 'failed') {
 		const updated = updateJobStatus(jobId, {
 			status: 'failed',
 			error: payload.error ?? 'Job failed without error details',
 			result_summary: payload.resultSummary,
 		});
-		cleanupJob(job);
-		log.info('job-completion', `job ${jobId} failed: ${payload.error}`);
+		log.info('job-completion', `job ${jobId} failed via callback: ${payload.error}`);
 		return updated!;
 	}
 
-	// Simple done transition — the poller handles the state machine
-	const updates: Parameters<typeof updateJobStatus>[1] = {
-		status: 'done',
-		result_summary: payload.resultSummary,
-	};
+	// Reconstruct the assistant text markers from the callback payload
+	// so handleJobAgentEnd can extract them and drive the state machine.
+	const markerLines: string[] = [];
+	if (payload.prUrl) markerLines.push(`PR_URL: ${payload.prUrl}`);
+	if (payload.verdict) markerLines.push(`VERDICT: ${payload.verdict}`);
+	if (payload.resultSummary) markerLines.push(payload.resultSummary);
+	const syntheticText = markerLines.join('\n');
 
-	if (payload.prUrl) {
-		updates.pr_url = payload.prUrl;
-	}
+	// Delegate to the state machine — this handles running → reviewing → done
+	handleJobAgentEnd(jobId, syntheticText);
 
-	if (payload.verdict) {
-		updates.review_verdict = payload.verdict;
-	}
-
-	const updatedJob = updateJobStatus(jobId, updates)!;
-	cleanupJob(job);
-
-	return updatedJob;
+	// Return the updated job (state may have changed)
+	return getJob(jobId) ?? job;
 }
 
 // --- Cleanup functions (exported for use by job-poller) ---
 
 /**
  * Clean up a job's resources: migrate sessions to repo directory, remove worktree.
+ * Only call this when the job has reached a terminal state.
  */
 export function cleanupJob(job: Job): void {
 	migrateWorktreeSessions(job);
@@ -132,15 +136,11 @@ function migrateWorktreeSessions(job: Job): void {
 // --- Worktree cleanup ---
 
 /**
- * Migrate session files to the repo's session directory, then remove the
- * git worktree using `git worktree remove` to properly unregister it from
- * git's tracking. Falls back to rmSync if git fails.
+ * Remove the git worktree using `git worktree remove` to properly unregister
+ * it from git's tracking. Falls back to rmSync if git fails.
  */
 function cleanupWorktree(job: Job): void {
 	if (!job.worktree_path) return;
-
-	// Copy session files to repo's session directory before cleanup
-	migrateWorktreeSessions(job);
 
 	// Try git worktree remove first (uses repo path if available)
 	try {

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -256,14 +256,16 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 			});
 
 			// Send review prompt to the SAME session
-			if (!job.session_id) {
-				throw new Error(`Job ${jobId} has no session_id`);
+			if (job.session_id) {
+				try {
+					const reviewPrompt = buildReviewPrompt(job);
+					await sendMessage(job.session_id, reviewPrompt);
+				} catch (err) {
+					log.warn('job-poller', `failed to send review prompt for job ${jobId}: ${err}`);
+				}
 			}
-
-			const reviewPrompt = buildReviewPrompt(job);
-			await sendMessage(job.session_id, reviewPrompt);
 			
-			log.info('job-poller', `job ${jobId} transitioned running → reviewing, sent review prompt`);
+			log.info('job-poller', `job ${jobId} transitioned running → reviewing`);
 			
 		} else if (job.status === 'reviewing') {
 			// Review phase complete → check verdict
@@ -306,15 +308,16 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 						review_verdict: 'changes_requested',
 					});
 
-					if (!job.session_id) {
-						throw new Error(`Job ${jobId} has no session_id`);
+					if (job.session_id) {
+						try {
+							const fixPrompt = buildTaskFixPrompt(job, assistantText);
+							await sendMessage(job.session_id, fixPrompt);
+						} catch (err) {
+							log.warn('job-poller', `failed to send fix prompt for job ${jobId}: ${err}`);
+						}
 					}
-
-					// Build fix prompt with review comments from the assistant text
-					const fixPrompt = buildTaskFixPrompt(job, assistantText);
-					await sendMessage(job.session_id, fixPrompt);
 					
-					log.info('job-poller', `job ${jobId} changes_requested → running (loop ${nextLoopCount}/${job.max_loops}), sent fix prompt`);
+					log.info('job-poller', `job ${jobId} changes_requested → running (loop ${nextLoopCount}/${job.max_loops})`);
 				}
 			} else {
 				// No verdict found — treat as failure


### PR DESCRIPTION
The extension callback was bypassing the review loop — marking jobs done immediately and nuking the worktree. Now it delegates to `handleJobAgentEnd` so the state machine drives transitions: `running → reviewing → done`.

Also makes `sendMessage` failures non-fatal — status updates commit first.