### PR TITLE
fix: fire-and-forget jobs transition to reviewing for manual inspection

### DIFF
--- a/src/lib/server/job-completion.test.ts
+++ b/src/lib/server/job-completion.test.ts
@@ -59,7 +59,7 @@ describe('job-completion', () => {
 			expect(updated.pr_url).toBe('https://github.com/org/repo/pull/1');
 		});
 
-		it('delegates to state machine — fire-and-forget goes straight to done', async () => {
+		it('delegates to state machine — fire-and-forget goes to reviewing (not done)', async () => {
 			const job = createJob({ title: 'Quick task', max_loops: 0 });
 			updateJobStatus(job.id, { status: 'running' });
 
@@ -70,7 +70,7 @@ describe('job-completion', () => {
 			});
 
 			const updated = getJob(job.id)!;
-			expect(updated.status).toBe('done');
+			expect(updated.status).toBe('reviewing');
 			expect(updated.pr_url).toBe('https://github.com/org/repo/pull/2');
 		});
 

--- a/src/lib/server/job-poller.test.ts
+++ b/src/lib/server/job-poller.test.ts
@@ -136,7 +136,7 @@ describe('job-poller', () => {
 			expect(updated.pr_url).toBe('https://github.com/org/repo/pull/99');
 		});
 
-		it('skips review and goes straight to done when max_loops is 0', async () => {
+		it('transitions to reviewing (not done) when max_loops is 0 — awaiting manual review', async () => {
 			const job = createJob({
 				title: 'Fire and forget task',
 				repo: '/repo',
@@ -147,9 +147,8 @@ describe('job-poller', () => {
 			await handleJobAgentEnd(job.id, 'Done!\nPR_URL: https://github.com/org/repo/pull/7');
 
 			const updated = getJob(job.id)!;
-			expect(updated.status).toBe('done');
+			expect(updated.status).toBe('reviewing');
 			expect(updated.pr_url).toBe('https://github.com/org/repo/pull/7');
-			// No reviewing state — went straight to done
 		});
 
 		it('stores model on job creation', () => {

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -232,31 +232,16 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 
 		// State machine transitions
 		if (job.status === 'running') {
-			// Task phase complete
+			// Task phase complete — always transition to reviewing
 			const prUrl = prUrlMatch?.[1];
 
-			// Skip review if max_loops === 0 (fire-and-forget task)
-			if (job.max_loops === 0) {
-				updateJobStatus(jobId, {
-					status: 'done',
-					pr_url: prUrl,
-				});
-
-				await cleanupJobAfterCompletion(job);
-				cleanupSubscription(jobId);
-
-				log.info('job-poller', `job ${jobId} completed (no review — max_loops=0)`);
-				return;
-			}
-
-			// Transition to review
 			updateJobStatus(jobId, {
 				status: 'reviewing',
 				pr_url: prUrl,
 			});
 
-			// Send review prompt to the SAME session
-			if (job.session_id) {
+			// Send review prompt if review loop is enabled (max_loops > 0)
+			if (job.max_loops > 0 && job.session_id) {
 				try {
 					const reviewPrompt = buildReviewPrompt(job);
 					await sendMessage(job.session_id, reviewPrompt);
@@ -265,7 +250,7 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 				}
 			}
 			
-			log.info('job-poller', `job ${jobId} transitioned running → reviewing`);
+			log.info('job-poller', `job ${jobId} transitioned running → reviewing${job.max_loops === 0 ? ' (awaiting manual review)' : ''}`);
 			
 		} else if (job.status === 'reviewing') {
 			// Review phase complete → check verdict

--- a/src/routes/api/jobs/[id]/+server.ts
+++ b/src/routes/api/jobs/[id]/+server.ts
@@ -5,6 +5,9 @@
  */
 import { json, error } from '@sveltejs/kit';
 import { getJob, updateJobStatus, deleteJob } from '$lib/server/job-queue';
+import { cleanupJob } from '$lib/server/job-completion';
+import { stopSession } from '$lib/server/rpc-manager';
+import { log } from '$lib/server/logger';
 import type { RequestHandler } from './$types';
 
 /** Allowed status transitions — maps current status to valid next statuses. */
@@ -53,6 +56,19 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 
 		const job = updateJobStatus(params.id, updates);
 		if (!job) throw error(404, 'Job not found');
+
+		// Run cleanup when transitioning to a terminal state via PATCH
+		if (updates.status === 'done' || updates.status === 'failed' || updates.status === 'cancelled') {
+			try {
+				cleanupJob(currentJob);
+				if (currentJob.session_id) {
+					await stopSession(currentJob.session_id);
+				}
+			} catch (err) {
+				log.warn('jobs-api', `cleanup after PATCH to ${updates.status} failed for job ${params.id}: ${err}`);
+			}
+		}
+
 		return json({ job });
 	} catch (e: any) {
 		if (e.status) throw e;


### PR DESCRIPTION
All jobs now go `running → reviewing` regardless of `max_loops`. When `max_loops=0`, no auto-review is sent — the job waits in `reviewing` for manual inspection. PATCH to `done` triggers cleanup (session migration + worktree removal).