### PR TITLE
fix: prevent kebab menu dropdown from being clipped by accordion overflow

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -402,7 +402,7 @@
 	{:else}
 		<div class="flex flex-col gap-4">
 			{#each projectGroups as group (group.cwd)}
-				<div class="rounded-lg border border-base-300 bg-base-200/50 overflow-hidden">
+				<div class="project-card rounded-lg border border-base-300 bg-base-200/50">
 					<!-- Project header -->
 					<div
 						class="flex w-full items-center gap-2 px-4 py-3 text-left hover:bg-base-300/50 transition-colors cursor-pointer"
@@ -625,3 +625,14 @@
 	defaultRepo={addJobRepo}
 	onclose={() => (showAddJob = false)}
 />
+
+<style>
+	/* Clip child content to rounded corners by default, but allow overflow
+	   when the kebab dropdown is focused so the menu isn't clipped */
+	.project-card {
+		overflow: hidden;
+	}
+	.project-card:has(.dropdown:focus-within) {
+		overflow: visible;
+	}
+</style>


### PR DESCRIPTION
## Problem

The kebab menu (three-dot menu) button on each project card's accordion header was being clipped when the accordion was collapsed. The dropdown menu content, which is absolutely positioned, was hidden by the `overflow-hidden` on the parent `.project-card` container (used to clip children at rounded border corners).

## Solution

- Moved the `overflow: hidden` from an inline Tailwind class to a scoped Svelte `<style>` block on the `.project-card` class
- Added a `:has(.dropdown:focus-within)` rule that switches to `overflow: visible` when the kebab dropdown is active
- When the dropdown loses focus (closes), overflow reverts to `hidden`, preserving the rounded corner clipping

This is a CSS-only fix with no JavaScript changes. The `:has()` selector is well-supported in modern browsers and works correctly with Svelte's scoped CSS.

## Testing

- All 265 unit tests pass
- svelte-check reports 0 errors and 0 warnings
- Build succeeds