### PR TITLE
fix: non-blocking slash commands and kebab menu overflow

### DIFF
--- a/src/lib/server/rpc-manager.ts
+++ b/src/lib/server/rpc-manager.ts
@@ -29,6 +29,8 @@ interface ManagedSession {
 	// Write queue for handling socket backpressure on large payloads
 	writeQueue: Uint8Array[];
 	writing: boolean;
+	// Cached commands — fetched once after connect, served instantly thereafter
+	cachedCommands: any[] | null;
 }
 
 interface ActiveSessionRow {
@@ -419,6 +421,7 @@ export async function resumeSession(
 			autoStopTimer: null,
 			writeQueue: [],
 			writing: false,
+			cachedCommands: null,
 		};
 
 		await connectToRelay(managed);
@@ -438,6 +441,9 @@ export async function resumeSession(
 		} catch {
 			/* process may not be ready yet */
 		}
+
+		// Pre-fetch commands in background so they're ready for slash completion
+		prefetchCommands(managed);
 	} catch (err) {
 		deleteActiveStmt.run(sessionId);
 		throw err;
@@ -472,6 +478,7 @@ export async function createSession(cwd: string, model?: string): Promise<string
 		autoStopTimer: null,
 		writeQueue: [],
 		writing: false,
+			cachedCommands: null,
 	};
 
 	await connectToRelay(managed);
@@ -514,6 +521,9 @@ export async function createSession(cwd: string, model?: string): Promise<string
 
 	// Record session created event
 	insertSessionEvent(sessionId, 'session_created');
+
+	// Pre-fetch commands in background so they're ready for slash completion
+	prefetchCommands(managed);
 
 	return sessionId;
 }
@@ -670,7 +680,32 @@ export async function getSessionStats(sessionId: string): Promise<any> {
 export async function getCommands(sessionId: string): Promise<any> {
 	const managed = activeSessions.get(sessionId);
 	if (!managed) throw new Error('Session not active');
-	return sendCommand(managed, { type: 'get_commands' }, COMMANDS_QUERY_TIMEOUT_MS);
+
+	// Return cached commands instantly — commands don't change during a session
+	if (managed.cachedCommands) {
+		return { commands: managed.cachedCommands };
+	}
+
+	// If not cached yet, trigger a background fetch and return empty
+	// The prefetch will populate the cache for the next request
+	prefetchCommands(managed);
+	return { commands: [] };
+}
+
+/**
+ * Pre-fetch and cache commands for a session in the background.
+ * Called after session connect when the agent is idle.
+ */
+function prefetchCommands(managed: ManagedSession): void {
+	if (managed.cachedCommands || managed.isStreaming) return;
+	sendCommand(managed, { type: 'get_commands' }, COMMANDS_QUERY_TIMEOUT_MS)
+		.then((result: any) => {
+			const commands = Array.isArray(result) ? result : (result?.commands ?? []);
+			if (commands.length > 0) {
+				managed.cachedCommands = commands;
+			}
+		})
+		.catch(() => { /* best effort — will retry on next request */ });
 }
 
 // --- Relay lifecycle helpers ---
@@ -752,6 +787,7 @@ export async function recoverActiveSessions() {
 					autoStopTimer: null,
 					writeQueue: [],
 					writing: false,
+			cachedCommands: null,
 				};
 
 				await connectToRelay(managed);
@@ -767,6 +803,7 @@ export async function recoverActiveSessions() {
 					}
 				} catch {}
 
+				prefetchCommands(managed);
 				reconnected++;
 				continue;
 			} catch (err) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -559,7 +559,7 @@
 
 					<!-- Sessions list -->
 					{#if expandedProjects.has(group.cwd)}
-						<div class="border-t border-base-300">
+						<div class="session-list border-t border-base-300">
 							{#each group.sessions as session, i (session.id)}
 								<SwipeToDelete
 									ondelete={() => deleteSession(session.id)}
@@ -627,12 +627,11 @@
 />
 
 <style>
-	/* Clip child content to rounded corners by default, but allow overflow
-	   when the kebab dropdown is focused so the menu isn't clipped */
 	.project-card {
-		overflow: hidden;
-	}
-	.project-card:has(.dropdown:focus-within) {
 		overflow: visible;
+	}
+	/* Clip session list inside the card but not the header */
+	.project-card .session-list {
+		overflow: hidden;
 	}
 </style>

--- a/src/routes/api/sessions/[id]/commands/+server.ts
+++ b/src/routes/api/sessions/[id]/commands/+server.ts
@@ -1,5 +1,5 @@
 import { getCommands, isActive } from '$lib/server/rpc-manager';
-import { json, error } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params }) => {
@@ -8,10 +8,10 @@ export const GET: RequestHandler = async ({ params }) => {
 	}
 	try {
 		const result = await getCommands(params.id);
-		// RPC may return { commands: [...] } or [...] directly
 		const commands = Array.isArray(result) ? result : (result?.commands ?? []);
 		return json({ commands });
-	} catch (e: any) {
-		throw error(500, `Failed to get commands: ${e.message || e}`);
+	} catch {
+		// Timeout or error — return empty, prefetch will populate cache eventually
+		return json({ commands: [] });
 	}
 };


### PR DESCRIPTION
**Slash commands:** Pre-fetches commands on session connect and caches on the managed session. `getCommands()` returns instantly from cache — never blocks on RPC. Client retry logic fills in if cache is cold.

**Kebab menu:** Moved overflow:hidden from project-card to session-list div so the dropdown isn't clipped by the accordion header.