### PR TITLE
fix: remove worktree cleanup logic from job completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Thumbs.db
 .env.*
 !.env.example
 !.env.test
+.kys-project.yaml
 
 # Vite
 vite.config.js.timestamp-*

--- a/src/lib/server/job-completion.test.ts
+++ b/src/lib/server/job-completion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'bun:test';
-import { handleCompletion, cwdToSessionDirName } from './job-completion';
+import { handleCompletion } from './job-completion';
 import { getJob, updateJobStatus } from './job-queue';
 import { createTestJob, cleanupTestJobs } from './test-helpers';
 
@@ -165,23 +165,5 @@ describe('job-completion', () => {
 		});
 	});
 
-	describe('cwdToSessionDirName', () => {
-		it('converts absolute path to pi session dir name', () => {
-			expect(cwdToSessionDirName('/Users/jchan/code/my-project')).toBe(
-				'--Users-jchan-code-my-project--'
-			);
-		});
 
-		it('handles paths with colons (Windows-style)', () => {
-			expect(cwdToSessionDirName('C:\\Users\\dev\\project')).toBe(
-				'--C--Users-dev-project--'
-			);
-		});
-
-		it('strips leading slash', () => {
-			const result = cwdToSessionDirName('/foo/bar');
-			expect(result).toBe('--foo-bar--');
-			expect(result.startsWith('---')).toBe(false);
-		});
-	});
 });

--- a/src/lib/server/job-completion.ts
+++ b/src/lib/server/job-completion.ts
@@ -1,17 +1,12 @@
 /**
- * Job completion handler — provides cleanup utilities for worktree and session migration.
+ * Job completion handler.
  * The main completion logic (state machine) is in job-poller.ts (handleJobAgentEnd).
  *
  * The extension callback delegates to handleJobAgentEnd so the review loop
  * is respected — it never directly marks a job as done.
  */
 import { getJob, updateJobStatus, type Job } from './job-queue';
-import { getDb } from './cache';
 import { log } from './logger';
-import { existsSync, mkdirSync, readdirSync, rmSync, copyFileSync } from 'fs';
-import { execFileSync } from 'child_process';
-import { join, resolve } from 'path';
-import { homedir } from 'os';
 
 // --- Types ---
 
@@ -66,9 +61,6 @@ export async function handleCompletion(jobId: string, payload: CompletionPayload
 		});
 		log.info('job-completion', `job ${jobId} failed via callback: ${payload.error}`);
 
-		// Still migrate sessions and clean up worktree on failure
-		cleanupJob(job);
-
 		return updated!;
 	}
 
@@ -107,111 +99,4 @@ export async function handleCompletion(jobId: string, payload: CompletionPayload
 	return getJob(jobId) ?? job;
 }
 
-// --- Cleanup functions (exported for use by job-poller) ---
 
-/**
- * Clean up a job's resources: migrate sessions to repo directory, remove worktree.
- * Only call this when the job has reached a terminal state.
- */
-export function cleanupJob(job: Job): void {
-	migrateWorktreeSessions(job);
-	cleanupWorktree(job);
-
-	// Clear worktree_path in the DB so the cache doesn't reference a removed directory
-	if (job.worktree_path) {
-		updateJobStatus(job.id, { worktree_path: null });
-	}
-}
-
-// --- Session migration ---
-
-const SESSIONS_DIR = join(homedir(), '.pi', 'agent', 'sessions');
-
-/**
- * Convert a cwd path to the session directory name pi uses.
- * Mirrors pi's internal convention: `--path-parts--`
- * Exported for testing.
- */
-export function cwdToSessionDirName(cwd: string): string {
-	return `--${cwd.replace(/^[/\\]/, '').replace(/[/\\:]/g, '-')}--`;
-}
-
-/**
- * Copy session files from the worktree's session directory to the repo's
- * session directory so they appear under the correct project in the dashboard.
- */
-function migrateWorktreeSessions(job: Job): void {
-	if (!job.worktree_path || !job.repo) return;
-
-	const worktreeSessionDir = join(SESSIONS_DIR, cwdToSessionDirName(resolve(job.worktree_path)));
-	const repoSessionDir = join(SESSIONS_DIR, cwdToSessionDirName(resolve(job.repo)));
-
-	if (!existsSync(worktreeSessionDir)) {
-		log.info('job-completion', `no worktree session dir to migrate: ${worktreeSessionDir}`);
-		return;
-	}
-
-	try {
-		mkdirSync(repoSessionDir, { recursive: true });
-
-		const files = readdirSync(worktreeSessionDir).filter(f => f.endsWith('.jsonl'));
-		for (const file of files) {
-			const src = join(worktreeSessionDir, file);
-			const dest = join(repoSessionDir, file);
-			copyFileSync(src, dest);
-		}
-
-		log.info('job-completion', `migrated ${files.length} session file(s) from worktree to repo: ${repoSessionDir}`);
-
-		// Remove the worktree session directory
-		rmSync(worktreeSessionDir, { recursive: true, force: true });
-		log.info('job-completion', `removed worktree session dir: ${worktreeSessionDir}`);
-
-		// Purge stale cache entries so the worktree doesn't appear as a project
-		const worktreeCwd = resolve(job.worktree_path);
-		const db = getDb();
-		const staleFiles = db.query('SELECT file_path FROM session_meta WHERE cwd = ?').all(worktreeCwd) as { file_path: string }[];
-		if (staleFiles.length > 0) {
-			const filePaths = staleFiles.map(r => r.file_path);
-			for (const fp of filePaths) {
-				db.run('DELETE FROM session_messages WHERE file_path = ?', [fp]);
-			}
-			db.run('DELETE FROM session_meta WHERE cwd = ?', [worktreeCwd]);
-			log.info('job-completion', `purged ${staleFiles.length} stale cache entries for worktree cwd: ${worktreeCwd}`);
-		}
-	} catch (err) {
-		log.warn('job-completion', `failed to migrate worktree sessions: ${err}`);
-	}
-}
-
-// --- Worktree cleanup ---
-
-/**
- * Remove the git worktree using `git worktree remove` to properly unregister
- * it from git's tracking. Falls back to rmSync if git fails.
- */
-function cleanupWorktree(job: Job): void {
-	if (!job.worktree_path) return;
-
-	// Try git worktree remove first (uses repo path if available)
-	try {
-		if (job.repo) {
-			execFileSync('git', ['worktree', 'remove', '--force', job.worktree_path], {
-				cwd: job.repo,
-				stdio: 'pipe',
-			});
-			log.info('job-completion', `removed worktree via git: ${job.worktree_path}`);
-			return;
-		}
-	} catch (err) {
-		log.warn('job-completion', `git worktree remove failed, falling back to rmSync: ${err}`);
-	}
-
-	// Fallback: remove the directory directly
-	try {
-		rmSync(job.worktree_path, { recursive: true, force: true });
-		log.info('job-completion', `cleaned up worktree via rmSync: ${job.worktree_path}`);
-	} catch (err) {
-		log.warn('job-completion', `failed to clean up worktree ${job.worktree_path}: ${err}`);
-	}
-}

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -1,17 +1,15 @@
 /**
  * Background poller that claims queued jobs and dispatches them to Pi sessions.
- * Creates git worktrees for isolation and spawns sessions via rpc-manager.
  * 
- * Jobs now use a single-job review loop model with phase transitions:
+ * Jobs use a single-job review loop model with phase transitions:
  * queued → claimed → running → reviewing → done/failed/cancelled
  */
 import { claimNextJob, updateJobStatus, getJob, type Job } from './job-queue';
-import { buildTaskPrompt, buildTaskFixPrompt, buildReviewPrompt, WORKTREE_BASE } from './job-prompts';
-import { cleanupJob } from './job-completion';
+import { buildTaskPrompt, buildTaskFixPrompt, buildReviewPrompt } from './job-prompts';
 import { createSession, sendMessage, subscribe, stopSession, isActive } from './rpc-manager';
 import { log } from './logger';
 import { getDb } from './cache';
-import { mkdirSync, existsSync } from 'fs';
+import { existsSync } from 'fs';
 
 // --- Constants ---
 
@@ -20,7 +18,6 @@ const POLL_INTERVAL_MS = 30_000;
 /** Patterns for extracting result markers from assistant text. */
 const PR_URL_PATTERN = /PR_URL:\s*(\S+)/;
 const VERDICT_PATTERN = /VERDICT:\s*(approved|changes_requested)/;
-const WORKTREE_PATH_PATTERN = /WORKTREE_PATH:\s*(\S+)/;
 
 /**
  * Fuzzy fallback patterns for verdict detection when the exact VERDICT marker
@@ -49,9 +46,6 @@ export function start(): void {
 		log.info('job-poller', 'poller already running');
 		return;
 	}
-
-	// Ensure worktree base directory exists (the agent creates worktrees here)
-	try { mkdirSync(WORKTREE_BASE, { recursive: true }); } catch { /* already exists */ }
 
 	// Recover jobs orphaned by a server restart before polling for new work
 	recoverOrphanedJobs();
@@ -107,19 +101,10 @@ export function recoverOrphanedJobs(): void {
 	).all() as Job[];
 
 	for (const job of orphaned) {
-		// Clean up any partial worktree that was created before the crash
-		if (job.worktree_path) {
-			try {
-				cleanupJob(job);
-			} catch (err) {
-				log.warn('job-poller', `failed to clean up orphaned worktree for job ${job.id}: ${err}`);
-			}
-		}
-
-		// Reset to queued — clear claimed_at and worktree_path so dispatch starts fresh
+		// Reset to queued — clear claimed_at so dispatch starts fresh
 		getDb().query(`
 			UPDATE jobs
-			SET status = 'queued', claimed_at = NULL, worktree_path = NULL, updated_at = datetime('now')
+			SET status = 'queued', claimed_at = NULL, updated_at = datetime('now')
 			WHERE id = ?
 		`).run(job.id);
 		log.info('job-poller', `recovered orphaned job ${job.id} (was ${job.status}) → re-queued`);
@@ -164,8 +149,6 @@ export async function pollOnce(): Promise<void> {
 
 /**
  * Create a Pi session in the repo directory and send the prompt.
- * Task jobs: the agent creates its own worktree via the issue-worker skill.
- * Review jobs: run directly in the repo — no worktree needed.
  */
 async function dispatchJob(job: Job): Promise<void> {
 	const isReview = job.type === 'review';
@@ -176,7 +159,6 @@ async function dispatchJob(job: Job): Promise<void> {
 			throw new Error(`Repository path not found: ${repoPath}`);
 		}
 
-		// All jobs start in the repo directory — task jobs create their own worktree
 		const sessionCwd = repoPath;
 
 		updateJobStatus(job.id, { status: 'running' });
@@ -215,7 +197,6 @@ async function dispatchJob(job: Job): Promise<void> {
 function subscribeToJobSession(jobId: string, sessionId: string): void {
 	// Accumulated assistant text for the current phase — reset between phases
 	let fullAssistantText = '';
-	let worktreePathCaptured = false;
 
 	const unsubscribe = subscribe(sessionId, (event: any) => {
 		// Accumulate assistant text deltas so we have the full conversation
@@ -223,16 +204,6 @@ function subscribeToJobSession(jobId: string, sessionId: string): void {
 			const ame = event.assistantMessageEvent;
 			if (ame?.type === 'text_delta') {
 				fullAssistantText += ame.delta;
-
-				// Extract WORKTREE_PATH as soon as it appears in the stream
-				if (!worktreePathCaptured) {
-					const wtMatch = fullAssistantText.match(WORKTREE_PATH_PATTERN);
-					if (wtMatch) {
-						worktreePathCaptured = true;
-						updateJobStatus(jobId, { worktree_path: wtMatch[1] });
-						log.info('job-poller', `captured worktree path for job ${jobId}: ${wtMatch[1]}`);
-					}
-				}
 			}
 		}
 
@@ -326,7 +297,7 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 						status: 'done',
 						review_verdict: verdict,
 					});
-					await cleanupJobAfterCompletion(job);
+					await stopJobSession(job);
 					cleanupSubscription(jobId);
 					log.info('job-poller', `review job ${jobId} → done (verdict: ${verdict})`);
 				} else {
@@ -335,7 +306,7 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 						status: 'failed',
 						error: 'Review ended without VERDICT marker',
 					});
-					await cleanupJobAfterCompletion(job);
+					await stopJobSession(job);
 					cleanupSubscription(jobId);
 				}
 				return;
@@ -345,7 +316,6 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 			const prUrl = prUrlMatch?.[1];
 
 			// All task jobs transition to reviewing when the agent ends.
-			// Worktrees are kept until the job is manually marked as done.
 			updateJobStatus(jobId, {
 				status: 'reviewing',
 				pr_url: prUrl,
@@ -362,7 +332,7 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 				}
 				log.info('job-poller', `job ${jobId} running → reviewing (review loop active)`);
 			} else {
-				// Fire-and-forget (max_loops=0): stop session, keep worktree.
+				// Fire-and-forget (max_loops=0): stop session.
 				// The user will manually review the PR and mark the job as done.
 				cleanupSubscription(jobId);
 				if (job.session_id) {
@@ -394,11 +364,10 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 					review_verdict: 'approved',
 				});
 
-				// Cleanup: migrate sessions, remove worktree, stop session
-				await cleanupJobAfterCompletion(job);
+				await stopJobSession(job);
 				cleanupSubscription(jobId);
 				
-				log.info('job-poller', `job ${jobId} approved → done, cleaned up`);
+				log.info('job-poller', `job ${jobId} approved → done`);
 				
 			} else if (verdict === 'changes_requested') {
 				const nextLoopCount = job.loop_count + 1;
@@ -411,7 +380,7 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 						result_summary: (job.result_summary ?? '') + '\n[Loop cap reached — review requested changes but no more fix iterations allowed]',
 					});
 
-					await cleanupJobAfterCompletion(job);
+					await stopJobSession(job);
 					cleanupSubscription(jobId);
 					
 					log.info('job-poller', `job ${jobId} loop cap reached (${job.max_loops}) → done`);
@@ -442,7 +411,7 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 					status: 'failed',
 					error: 'Review phase ended without VERDICT marker',
 				});
-				await cleanupJobAfterCompletion(job);
+				await stopJobSession(job);
 				cleanupSubscription(jobId);
 			}
 		}
@@ -454,34 +423,24 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 			error: `Phase transition failed: ${err}`,
 		});
 
-		// Ensure cleanup still runs — migrate sessions + remove worktree
 		const failedJob = getJob(jobId);
 		if (failedJob) {
-			await cleanupJobAfterCompletion(failedJob);
+			await stopJobSession(failedJob);
 		}
 		cleanupSubscription(jobId);
 	}
 }
 
 /**
- * Cleanup after a job completes (done/failed/cancelled).
- * Migrates sessions, removes worktree, and stops the session.
+ * Stop the Pi session associated with a job.
  */
-async function cleanupJobAfterCompletion(job: Job): Promise<void> {
+async function stopJobSession(job: Job): Promise<void> {
+	if (!job.session_id) return;
 	try {
-		await cleanupJob(job);
-		
-		// Stop the session if it's still running
-		if (job.session_id) {
-			try {
-				await stopSession(job.session_id);
-				log.info('job-poller', `stopped session ${job.session_id} for job ${job.id}`);
-			} catch (err) {
-				log.warn('job-poller', `failed to stop session ${job.session_id}: ${err}`);
-			}
-		}
+		await stopSession(job.session_id);
+		log.info('job-poller', `stopped session ${job.session_id} for job ${job.id}`);
 	} catch (err) {
-		log.error('job-poller', `cleanup failed for job ${job.id}: ${err}`);
+		log.warn('job-poller', `failed to stop session ${job.session_id}: ${err}`);
 	}
 }
 

--- a/src/lib/server/job-prompts.ts
+++ b/src/lib/server/job-prompts.ts
@@ -10,12 +10,6 @@
  */
 import type { Job } from './job-queue';
 import { getOrigin } from './origin';
-import { join } from 'path';
-
-// --- Worktree configuration ---
-
-export const WORKTREE_BASE = process.env.PI_WORKTREE_DIR || join(process.cwd(), '.worktrees');
-
 // --- Skill configuration from environment ---
 
 /** Skill for fire-and-forget tasks (max_loops=0). e.g. 'issue-worker' */
@@ -36,7 +30,7 @@ function metadataHeader(job: Job): string {
 	].join('\n');
 }
 
-/** Build the common task context lines (title, description, issue, branch, worktree). */
+/** Build the common task context lines (title, description, issue, branch). */
 function taskContext(job: Job): string[] {
 	const lines: string[] = [];
 	lines.push(job.title);
@@ -44,9 +38,7 @@ function taskContext(job: Job): string[] {
 	if (job.issue_url) lines.push(`Issue: ${job.issue_url}`);
 	if (job.branch) lines.push(`Branch: ${job.branch}`);
 	if (job.target_branch) lines.push(`Target branch: ${job.target_branch}`);
-	// Worktree context — tells the skill to create an isolated worktree
 	lines.push(`Job ID: ${job.id}`);
-	lines.push(`Worktree dir: ${WORKTREE_BASE}`);
 	return lines;
 }
 

--- a/src/lib/server/job-queue.ts
+++ b/src/lib/server/job-queue.ts
@@ -30,7 +30,6 @@ export interface Job {
 	loop_count: number;
 	max_loops: number;
 	session_id: string | null;
-	worktree_path: string | null;
 	result_summary: string | null;
 	error: string | null;
 	retry_count: number;
@@ -63,7 +62,6 @@ export interface UpdateJobInput {
 	pr_number?: number;
 	review_verdict?: Job['review_verdict'];
 	session_id?: string;
-	worktree_path?: string | null;
 	result_summary?: string;
 	error?: string;
 	branch?: string;
@@ -168,7 +166,6 @@ export function updateJobStatus(id: string, updates: UpdateJobInput): Job | null
 	if (updates.pr_number !== undefined) { setClauses.push('pr_number = $pr_number'); params.$pr_number = updates.pr_number; }
 	if (updates.review_verdict !== undefined) { setClauses.push('review_verdict = $review_verdict'); params.$review_verdict = updates.review_verdict; }
 	if (updates.session_id !== undefined) { setClauses.push('session_id = $session_id'); params.$session_id = updates.session_id; }
-	if (updates.worktree_path !== undefined) { setClauses.push('worktree_path = $worktree_path'); params.$worktree_path = updates.worktree_path; }
 	if (updates.result_summary !== undefined) { setClauses.push('result_summary = $result_summary'); params.$result_summary = updates.result_summary; }
 	if (updates.error !== undefined) { setClauses.push('error = $error'); params.$error = updates.error; }
 	if (updates.branch !== undefined) { setClauses.push('branch = $branch'); params.$branch = updates.branch; }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -6,13 +6,8 @@ import { getJobs } from '$lib/server/job-queue';
 import { isRunning as isPollerRunning } from '$lib/server/job-poller';
 import type { PageServerLoad } from './$types';
 
-/** Pattern matching worktree directories created by the job poller. */
-const WORKTREE_CWD_PATTERN = /\/\.worktrees\/job-/;
-
 export const load: PageServerLoad = async () => {
-	const allSessions = await listSessions();
-	// Hide sessions running inside job worktrees — they clutter the dashboard
-	const sessions = allSessions.filter((s) => !WORKTREE_CWD_PATTERN.test(s.cwd));
+	const sessions = await listSessions();
 	const activeSessionIds = [...getActiveSessionIds()];
 	const streamingSessionIds = activeSessionIds.filter(
 		(id) => getStreamingState(id).isStreaming

--- a/src/routes/api/jobs/[id]/+server.ts
+++ b/src/routes/api/jobs/[id]/+server.ts
@@ -5,7 +5,6 @@
  */
 import { json, error } from '@sveltejs/kit';
 import { getJob, updateJobStatus, deleteJob } from '$lib/server/job-queue';
-import { cleanupJob } from '$lib/server/job-completion';
 import { stopSession } from '$lib/server/rpc-manager';
 import { log } from '$lib/server/logger';
 import type { RequestHandler } from './$types';
@@ -22,7 +21,7 @@ const VALID_TRANSITIONS: Record<string, string[]> = {
 	cancelled: [],
 };
 
-/** Fields that can be updated via PATCH. Rejects internal-only fields like session_id and worktree_path. */
+/** Fields that can be updated via PATCH. Rejects internal-only fields like session_id. */
 const ALLOWED_PATCH_FIELDS = ['status', 'pr_url', 'pr_number', 'review_verdict', 'result_summary', 'branch', 'review_skill'] as const;
 
 export const GET: RequestHandler = async ({ params }) => {
@@ -57,15 +56,14 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 		const job = updateJobStatus(params.id, updates);
 		if (!job) throw error(404, 'Job not found');
 
-		// Run cleanup when transitioning to a terminal state via PATCH
+		// Stop the session when transitioning to a terminal state via PATCH
 		if (updates.status === 'done' || updates.status === 'failed' || updates.status === 'cancelled') {
-			try {
-				cleanupJob(currentJob);
-				if (currentJob.session_id) {
+			if (currentJob.session_id) {
+				try {
 					await stopSession(currentJob.session_id);
+				} catch (err) {
+					log.warn('jobs-api', `failed to stop session after PATCH to ${updates.status} for job ${params.id}: ${err}`);
 				}
-			} catch (err) {
-				log.warn('jobs-api', `cleanup after PATCH to ${updates.status} failed for job ${params.id}: ${err}`);
 			}
 		}
 


### PR DESCRIPTION
The app no longer manages worktrees — the agent/skill handles worktree creation itself. This removes all worktree-related cleanup code that could potentially wipe directories via `rmSync` or `git worktree remove --force`.

### Changes
- Remove `cleanupJob`, `cleanupWorktree`, `migrateWorktreeSessions` from job-completion.ts
- Remove `WORKTREE_PATH` stream capture from job session subscription
- Remove `WORKTREE_BASE` dir creation from poller startup
- Remove `worktree_path` from Job type and update handler
- Remove worktree session filter from dashboard home page
- Strip worktree dir from task prompt context
- Replace `cleanupJobAfterCompletion` with simple `stopJobSession`

The `worktree_path` column remains in the DB schema (harmless, avoids migration).