### PR TITLE
feat: smart retry logic for no-verdict failures

### DIFF
--- a/src/lib/server/cache.ts
+++ b/src/lib/server/cache.ts
@@ -97,6 +97,8 @@ export function getDb(): Database {
 			error TEXT,
 			retry_count INTEGER NOT NULL DEFAULT 0,
 			max_retries INTEGER NOT NULL DEFAULT 2,
+			no_verdict_retries INTEGER NOT NULL DEFAULT 0,
+			max_no_verdict_retries INTEGER NOT NULL DEFAULT 3,
 			callback_token TEXT NOT NULL DEFAULT (lower(hex(randomblob(16)))),
 			review_skill TEXT,
 			model TEXT
@@ -106,6 +108,8 @@ export function getDb(): Database {
 		try { db.run('ALTER TABLE jobs ADD COLUMN callback_token TEXT NOT NULL DEFAULT (lower(hex(randomblob(16))))'); } catch {}
 		try { db.run('ALTER TABLE jobs ADD COLUMN review_skill TEXT'); } catch {}
 		try { db.run('ALTER TABLE jobs ADD COLUMN model TEXT'); } catch {}
+		try { db.run('ALTER TABLE jobs ADD COLUMN no_verdict_retries INTEGER NOT NULL DEFAULT 0'); } catch {}
+		try { db.run('ALTER TABLE jobs ADD COLUMN max_no_verdict_retries INTEGER NOT NULL DEFAULT 3'); } catch {}
 
 		// Migration: Test if 'reviewing' status is allowed by trying a test insert
 		// If it fails, we need to migrate the schema to remove CHECK constraints
@@ -148,6 +152,8 @@ export function getDb(): Database {
 				error TEXT,
 				retry_count INTEGER NOT NULL DEFAULT 0,
 				max_retries INTEGER NOT NULL DEFAULT 2,
+				no_verdict_retries INTEGER NOT NULL DEFAULT 0,
+				max_no_verdict_retries INTEGER NOT NULL DEFAULT 3,
 				callback_token TEXT NOT NULL DEFAULT (lower(hex(randomblob(16)))),
 				review_skill TEXT,
 				model TEXT

--- a/src/lib/server/job-poller.test.ts
+++ b/src/lib/server/job-poller.test.ts
@@ -214,6 +214,67 @@ describe('job-poller', () => {
 		});
 	});
 
+	describe('handleJobAgentEnd — no verdict nudge retry', () => {
+		it('fails review-type job without verdict when session is inactive (nudge cannot be sent)', async () => {
+			const job = createTestJob({
+				type: 'review',
+				title: 'Review with no verdict',
+				repo: '/repo',
+				pr_url: 'https://github.com/org/repo/pull/50',
+			});
+			updateJobStatus(job.id, { status: 'running', session_id: 'test-session' });
+
+			await handleJobAgentEnd(job.id, 'I reviewed the code but forgot the verdict.');
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('failed');
+			expect(updated.error).toContain('VERDICT');
+			expect(updated.error).toContain('retry');
+		});
+
+		it('fails reviewing-phase job without verdict when session is inactive (nudge cannot be sent)', async () => {
+			const job = createTestJob({
+				title: 'Task review no verdict',
+				repo: '/repo',
+				max_loops: 3,
+			});
+			updateJobStatus(job.id, { status: 'reviewing', session_id: 'test-session' });
+
+			await handleJobAgentEnd(job.id, 'I looked at the changes but no verdict.');
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('failed');
+			expect(updated.error).toContain('VERDICT');
+			expect(updated.error).toContain('retry');
+		});
+
+		it('includes retry count in error message when nudges are exhausted', async () => {
+			const job = createTestJob({
+				type: 'review',
+				title: 'Exhausted nudges',
+				repo: '/repo',
+				pr_url: 'https://github.com/org/repo/pull/60',
+			});
+			// Simulate having already used all nudge retries
+			updateJobStatus(job.id, { status: 'running', session_id: 'test-session', no_verdict_retries: 3 });
+
+			await handleJobAgentEnd(job.id, 'No verdict here.');
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('failed');
+			expect(updated.error).toContain('3 retry');
+		});
+
+		it('defaults max_no_verdict_retries to 3', () => {
+			const job = createTestJob({
+				title: 'Check defaults',
+				repo: '/repo',
+			});
+			expect(job.no_verdict_retries).toBe(0);
+			expect(job.max_no_verdict_retries).toBe(3);
+		});
+	});
+
 	describe('recoverOrphanedJobs', () => {
 		it('re-queues a claimed job with no session_id', () => {
 			const job = createTestJob({ title: 'Orphaned claimed', repo: '/repo' });

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -5,7 +5,7 @@
  * queued → claimed → running → reviewing → done/failed/cancelled
  */
 import { claimNextJob, updateJobStatus, getJob, type Job } from './job-queue';
-import { buildTaskPrompt, buildTaskFixPrompt, buildReviewPrompt } from './job-prompts';
+import { buildTaskPrompt, buildTaskFixPrompt, buildReviewPrompt, buildNudgeVerdictPrompt } from './job-prompts';
 import { createSession, sendMessage, subscribe, stopSession, isActive } from './rpc-manager';
 import { log } from './logger';
 import { getDb } from './cache';
@@ -300,11 +300,14 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 					await stopJobSession(job);
 					cleanupSubscription(jobId);
 					log.info('job-poller', `review job ${jobId} → done (verdict: ${verdict})`);
+				} else if (await nudgeForVerdict(job)) {
+					// Nudge sent — wait for next agent_end
+					return;
 				} else {
-					log.warn('job-poller', `review job ${jobId} ended without verdict — marking as failed`);
+					log.warn('job-poller', `review job ${jobId} ended without verdict after ${job.no_verdict_retries} nudges — marking as failed`);
 					updateJobStatus(jobId, {
 						status: 'failed',
-						error: 'Review ended without VERDICT marker',
+						error: `Review ended without VERDICT marker after ${job.no_verdict_retries} retry attempts`,
 					});
 					await stopJobSession(job);
 					cleanupSubscription(jobId);
@@ -404,12 +407,14 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 					
 					log.info('job-poller', `job ${jobId} changes_requested → running (loop ${nextLoopCount}/${job.max_loops})`);
 				}
+			} else if (await nudgeForVerdict(job)) {
+				// Nudge sent — wait for next agent_end
 			} else {
-				// No verdict found — treat as failure
-				log.warn('job-poller', `job ${jobId} review phase ended without verdict — marking as failed`);
+				// No verdict found and nudges exhausted — treat as failure
+				log.warn('job-poller', `job ${jobId} review phase ended without verdict after ${job.no_verdict_retries} nudges — marking as failed`);
 				updateJobStatus(jobId, {
 					status: 'failed',
-					error: 'Review phase ended without VERDICT marker',
+					error: `Review phase ended without VERDICT marker after ${job.no_verdict_retries} retry attempts`,
 				});
 				await stopJobSession(job);
 				cleanupSubscription(jobId);
@@ -428,6 +433,42 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 			await stopJobSession(failedJob);
 		}
 		cleanupSubscription(jobId);
+	}
+}
+
+/**
+ * Nudge a stalled job by sending a follow-up prompt asking the agent to
+ * provide a VERDICT. Returns true if a nudge was sent (still has retries),
+ * false if retries are exhausted.
+ */
+async function nudgeForVerdict(job: Job): Promise<boolean> {
+	const nextRetry = job.no_verdict_retries + 1;
+	if (nextRetry > job.max_no_verdict_retries) {
+		return false;
+	}
+
+	if (!job.session_id) {
+		log.warn('job-poller', `cannot nudge job ${job.id} — no session_id`);
+		return false;
+	}
+
+	try {
+		// Check the session is still alive before nudging
+		if (!isActive(job.session_id)) {
+			log.warn('job-poller', `cannot nudge job ${job.id} — session ${job.session_id} is no longer active`);
+			return false;
+		}
+
+		updateJobStatus(job.id, { no_verdict_retries: nextRetry });
+
+		const nudgePrompt = buildNudgeVerdictPrompt(job, nextRetry);
+		await sendMessage(job.session_id, nudgePrompt);
+
+		log.info('job-poller', `nudged job ${job.id} for verdict (attempt ${nextRetry}/${job.max_no_verdict_retries})`);
+		return true;
+	} catch (err) {
+		log.warn('job-poller', `failed to nudge job ${job.id}: ${err}`);
+		return false;
 	}
 }
 

--- a/src/lib/server/job-prompts.test.ts
+++ b/src/lib/server/job-prompts.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'bun:test';
+import { buildNudgeVerdictPrompt } from './job-prompts';
+import type { Job } from './job-queue';
+
+/** Minimal job fixture for prompt tests. */
+function makeJob(overrides?: Partial<Job>): Job {
+	return {
+		id: 'test-job-id',
+		type: 'review',
+		status: 'running',
+		priority: 0,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+		claimed_at: null,
+		completed_at: null,
+		title: 'Test job',
+		description: null,
+		repo: '/repo',
+		branch: null,
+		issue_url: null,
+		target_branch: 'main',
+		pr_url: null,
+		pr_number: null,
+		review_verdict: null,
+		parent_job_id: null,
+		loop_count: 0,
+		max_loops: 0,
+		session_id: null,
+		result_summary: null,
+		error: null,
+		retry_count: 0,
+		max_retries: 2,
+		no_verdict_retries: 0,
+		max_no_verdict_retries: 3,
+		callback_token: 'test-token',
+		review_skill: null,
+		model: null,
+		...overrides,
+	};
+}
+
+describe('job-prompts', () => {
+	describe('buildNudgeVerdictPrompt', () => {
+		it('includes attempt number and max retries', () => {
+			const job = makeJob({ max_no_verdict_retries: 3 });
+			const prompt = buildNudgeVerdictPrompt(job, 1);
+
+			expect(prompt).toContain('attempt 1 of 3');
+		});
+
+		it('includes both VERDICT markers', () => {
+			const job = makeJob();
+			const prompt = buildNudgeVerdictPrompt(job, 2);
+
+			expect(prompt).toContain('VERDICT: approved');
+			expect(prompt).toContain('VERDICT: changes_requested');
+		});
+
+		it('mentions the job will fail without a verdict', () => {
+			const job = makeJob();
+			const prompt = buildNudgeVerdictPrompt(job, 1);
+
+			expect(prompt).toContain('FAIL');
+		});
+
+		it('mentions the agent stopped without a verdict', () => {
+			const job = makeJob();
+			const prompt = buildNudgeVerdictPrompt(job, 1);
+
+			expect(prompt).toContain('stopped without providing a VERDICT');
+		});
+	});
+});

--- a/src/lib/server/job-prompts.ts
+++ b/src/lib/server/job-prompts.ts
@@ -91,6 +91,29 @@ export function buildTaskFixPrompt(job: Job, _reviewComments: string): string {
 	return parts.join('\n');
 }
 
+// --- Nudge verdict prompt (sent when agent ends without a VERDICT) ---
+
+export function buildNudgeVerdictPrompt(job: Job, attempt: number): string {
+	const parts: string[] = [];
+
+	parts.push(`You stopped without providing a VERDICT. This is attempt ${attempt} of ${job.max_no_verdict_retries}.`);
+	parts.push('');
+	parts.push('If you are stalled or have finished your review, please provide your verdict now.');
+	parts.push('If you have not finished, continue your work and then provide the verdict.');
+	parts.push('');
+	parts.push('=== CRITICAL: REQUIRED OUTPUT ===');
+	parts.push('You MUST output EXACTLY one of these two lines as the VERY LAST thing in your response:');
+	parts.push('');
+	parts.push('VERDICT: approved');
+	parts.push('VERDICT: changes_requested');
+	parts.push('');
+	parts.push('This is a machine-parsed marker. The job will FAIL if you do not include it.');
+	parts.push('Do NOT paraphrase, reword, or wrap it in a code block. Output the exact line on its own.');
+	parts.push('=================================');
+
+	return parts.join('\n');
+}
+
 // --- Review prompt ---
 
 export function buildReviewPrompt(job: Job): string {

--- a/src/lib/server/job-queue.ts
+++ b/src/lib/server/job-queue.ts
@@ -34,6 +34,8 @@ export interface Job {
 	error: string | null;
 	retry_count: number;
 	max_retries: number;
+	no_verdict_retries: number;
+	max_no_verdict_retries: number;
 	callback_token: string;
 	review_skill: string | null;
 	model: string | null;
@@ -67,6 +69,7 @@ export interface UpdateJobInput {
 	branch?: string;
 	review_skill?: string;
 	loop_count?: number;
+	no_verdict_retries?: number;
 }
 
 // --- Query helpers ---
@@ -171,6 +174,7 @@ export function updateJobStatus(id: string, updates: UpdateJobInput): Job | null
 	if (updates.branch !== undefined) { setClauses.push('branch = $branch'); params.$branch = updates.branch; }
 	if (updates.review_skill !== undefined) { setClauses.push('review_skill = $review_skill'); params.$review_skill = updates.review_skill; }
 	if (updates.loop_count !== undefined) { setClauses.push('loop_count = $loop_count'); params.$loop_count = updates.loop_count; }
+	if (updates.no_verdict_retries !== undefined) { setClauses.push('no_verdict_retries = $no_verdict_retries'); params.$no_verdict_retries = updates.no_verdict_retries; }
 
 	const sql = `UPDATE jobs SET ${setClauses.join(', ')} WHERE id = $id RETURNING *`;
 	const row = getDb().query(sql).get(params) as Job | null;

--- a/src/routes/jobs/+page.svelte
+++ b/src/routes/jobs/+page.svelte
@@ -35,6 +35,8 @@
 		error: string | null;
 		retry_count: number;
 		max_retries: number;
+		no_verdict_retries: number;
+		max_no_verdict_retries: number;
 		model: string | null;
 	}
 
@@ -424,6 +426,12 @@
 						<div class="flex gap-2">
 							<span class="text-base-content/50 w-20 flex-shrink-0">Retries</span>
 							<span>{job.retry_count}/{job.max_retries}</span>
+						</div>
+					{/if}
+					{#if job.no_verdict_retries > 0}
+						<div class="flex gap-2">
+							<span class="text-base-content/50 w-20 flex-shrink-0">Nudges</span>
+							<span>{job.no_verdict_retries}/{job.max_no_verdict_retries}</span>
 						</div>
 					{/if}
 					{#if job.session_id}


### PR DESCRIPTION
## Problem
Jobs frequently fail with "no verdict" errors when the agent ends without outputting the required `VERDICT: approved` or `VERDICT: changes_requested` marker.

## Solution
Instead of immediately marking jobs as failed when no verdict is detected, the system now **nudges the agent** with a follow-up prompt asking it to continue and provide a verdict. This happens up to **3 times** (configurable) before giving up.

### How it works
1. Agent ends without a VERDICT marker
2. System checks if nudge retries remain (`no_verdict_retries < max_no_verdict_retries`)
3. If the session is still active, sends a nudge prompt: *"You stopped without providing a VERDICT. This is attempt N of 3..."*
4. Increments `no_verdict_retries` counter on the job
5. Waits for the next `agent_end` event
6. Only marks as failed after all nudge attempts are exhausted (or if the session is no longer active)

### Changes
- **DB schema**: Add `no_verdict_retries` (default 0) and `max_no_verdict_retries` (default 3) columns with migration support
- **job-poller.ts**: Add `nudgeForVerdict()` — checks session is alive, increments counter, sends nudge prompt
- **job-prompts.ts**: Add `buildNudgeVerdictPrompt()` — clear prompt reminding the agent to output a VERDICT
- **job-queue.ts**: Extend `Job` type and `UpdateJobInput` with new fields
- **jobs page**: Display nudge count in the expanded job detail view
- **Tests**: 8 new tests covering nudge behaviour, prompt content, and defaults