### PR TITLE
feat: add ABORT_JOB marker to short-circuit nudge retries

### DIFF
--- a/src/lib/server/job-poller.test.ts
+++ b/src/lib/server/job-poller.test.ts
@@ -275,6 +275,85 @@ describe('job-poller', () => {
 		});
 	});
 
+	describe('handleJobAgentEnd — ABORT_JOB', () => {
+		it('immediately fails a running review job when ABORT_JOB is present', async () => {
+			const job = createTestJob({
+				type: 'review',
+				title: 'Review missing PR',
+				repo: '/repo',
+				pr_url: 'https://github.com/org/repo/pull/404',
+			});
+			updateJobStatus(job.id, { status: 'running', session_id: 'test-session' });
+
+			await handleJobAgentEnd(job.id, 'The PR does not exist.\nABORT_JOB: PR not found - repository returned 404');
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('failed');
+			expect(updated.error).toContain('Aborted by agent');
+			expect(updated.error).toContain('PR not found');
+		});
+
+		it('immediately fails a reviewing-phase job when ABORT_JOB is present', async () => {
+			const job = createTestJob({
+				title: 'Task with bad repo',
+				repo: '/repo',
+				max_loops: 3,
+			});
+			updateJobStatus(job.id, { status: 'reviewing', session_id: 'test-session' });
+
+			await handleJobAgentEnd(job.id, 'Cannot find the repo.\nABORT_JOB: Repository does not exist');
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('failed');
+			expect(updated.error).toContain('Aborted by agent');
+			expect(updated.error).toContain('Repository does not exist');
+		});
+
+		it('ABORT_JOB takes precedence over VERDICT marker', async () => {
+			const job = createTestJob({
+				type: 'review',
+				title: 'Conflicting markers',
+				repo: '/repo',
+			});
+			updateJobStatus(job.id, { status: 'running', session_id: 'test-session' });
+
+			await handleJobAgentEnd(job.id, 'VERDICT: approved\nABORT_JOB: Something is fundamentally wrong');
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('failed');
+			expect(updated.error).toContain('Aborted by agent');
+		});
+
+		it('ABORT_JOB skips nudge retries entirely', async () => {
+			const job = createTestJob({
+				type: 'review',
+				title: 'Skip nudges',
+				repo: '/repo',
+			});
+			// Still has nudge retries available
+			updateJobStatus(job.id, { status: 'running', session_id: 'test-session', no_verdict_retries: 0 });
+
+			await handleJobAgentEnd(job.id, 'ABORT_JOB: Issue cannot be found');
+
+			const updated = getJob(job.id)!;
+			expect(updated.status).toBe('failed');
+			// no_verdict_retries should not have been incremented
+			expect(updated.no_verdict_retries).toBe(0);
+		});
+
+		it('does not abort for terminal-state jobs', async () => {
+			const job = createTestJob({
+				title: 'Already done',
+				repo: '/repo',
+			});
+			updateJobStatus(job.id, { status: 'done' });
+
+			await handleJobAgentEnd(job.id, 'ABORT_JOB: Too late');
+
+			expect(getJob(job.id)!.status).toBe('done');
+		});
+	});
+
 	describe('recoverOrphanedJobs', () => {
 		it('re-queues a claimed job with no session_id', () => {
 			const job = createTestJob({ title: 'Orphaned claimed', repo: '/repo' });

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -26,6 +26,9 @@ const VERDICT_PATTERN = /VERDICT:\s*(approved|changes_requested)/;
 const VERDICT_FALLBACK_APPROVED = /\b(?:gh pr review \d+ --approve|LGTM|looks good to merge|approving this PR)\b/i;
 const VERDICT_FALLBACK_CHANGES = /\b(?:gh pr review \d+ --request-changes|requesting changes|changes are needed|must fix before merge)\b/i;
 
+/** Pattern for the agent to signal an unrecoverable error and abort the job. */
+const ABORT_JOB_PATTERN = /ABORT_JOB:\s*(.+)/;
+
 // --- State ---
 
 let pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -283,7 +286,23 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 		const prUrlMatch = assistantText.match(PR_URL_PATTERN);
 		const verdictMatch = assistantText.match(VERDICT_PATTERN);
 
-		log.info('job-poller', `agent_end for job ${jobId} (status=${job.status}) — prUrl=${prUrlMatch?.[1] ?? 'none'}, verdict=${verdictMatch?.[1] ?? 'none'}`);
+		// Check for agent-initiated abort (unrecoverable error)
+		const abortMatch = assistantText.match(ABORT_JOB_PATTERN);
+
+		log.info('job-poller', `agent_end for job ${jobId} (status=${job.status}) — prUrl=${prUrlMatch?.[1] ?? 'none'}, verdict=${verdictMatch?.[1] ?? 'none'}, abort=${abortMatch ? 'yes' : 'no'}`);
+
+		// ABORT_JOB short-circuits all state transitions — fail immediately
+		if (abortMatch) {
+			const reason = abortMatch[1].trim();
+			log.warn('job-poller', `job ${jobId} aborted by agent: ${reason}`);
+			updateJobStatus(jobId, {
+				status: 'failed',
+				error: `Aborted by agent: ${reason}`,
+			});
+			await stopJobSession(job);
+			cleanupSubscription(jobId);
+			return;
+		}
 
 		// State machine transitions
 		if (job.status === 'running') {

--- a/src/lib/server/job-prompts.test.ts
+++ b/src/lib/server/job-prompts.test.ts
@@ -69,5 +69,19 @@ describe('job-prompts', () => {
 
 			expect(prompt).toContain('stopped without providing a VERDICT');
 		});
+
+		it('includes the ABORT_JOB escape hatch', () => {
+			const job = makeJob();
+			const prompt = buildNudgeVerdictPrompt(job, 1);
+
+			expect(prompt).toContain('ABORT_JOB:');
+		});
+
+		it('explains when to use ABORT_JOB', () => {
+			const job = makeJob();
+			const prompt = buildNudgeVerdictPrompt(job, 1);
+
+			expect(prompt).toContain('unrecoverable error');
+		});
 	});
 });

--- a/src/lib/server/job-prompts.ts
+++ b/src/lib/server/job-prompts.ts
@@ -102,12 +102,18 @@ export function buildNudgeVerdictPrompt(job: Job, attempt: number): string {
 	parts.push('If you have not finished, continue your work and then provide the verdict.');
 	parts.push('');
 	parts.push('=== CRITICAL: REQUIRED OUTPUT ===');
-	parts.push('You MUST output EXACTLY one of these two lines as the VERY LAST thing in your response:');
+	parts.push('You MUST output EXACTLY one of these lines as the VERY LAST thing in your response:');
 	parts.push('');
 	parts.push('VERDICT: approved');
 	parts.push('VERDICT: changes_requested');
 	parts.push('');
-	parts.push('This is a machine-parsed marker. The job will FAIL if you do not include it.');
+	parts.push('If you cannot complete this job due to an unrecoverable error (e.g. the issue,');
+	parts.push('repo, or PR does not exist, or you lack the information needed to proceed),');
+	parts.push('output this instead:');
+	parts.push('');
+	parts.push('ABORT_JOB: <reason>');
+	parts.push('');
+	parts.push('These are machine-parsed markers. The job will FAIL if you do not include one.');
 	parts.push('Do NOT paraphrase, reword, or wrap it in a code block. Output the exact line on its own.');
 	parts.push('=================================');
 


### PR DESCRIPTION
## Problem
When a job fails due to an unrecoverable error (repo doesn't exist, PR returned 404, issue not found), the nudge retry system burns through all 3 attempts before finally failing — wasting time and tokens.

## Solution
Add an `ABORT_JOB: <reason>` marker that the agent can output to immediately fail the job, skipping any remaining nudge retries.

### How it works
1. Agent encounters an unrecoverable error during a nudge retry
2. Outputs `ABORT_JOB: <reason>` instead of a VERDICT
3. Job immediately transitions to `failed` with `Aborted by agent: <reason>`
4. No further nudges are sent, session is cleaned up

### Behaviour
- `ABORT_JOB` takes precedence over `VERDICT` if both are present
- Works in all job phases (running review jobs, reviewing phase)
- Terminal-state jobs are unaffected (existing guard)
- The nudge prompt explains when to use it (unrecoverable errors)

### Changes
- **job-poller.ts**: Add `ABORT_JOB_PATTERN`, check before state transitions
- **job-prompts.ts**: Update nudge prompt with `ABORT_JOB:` escape hatch
- **Tests**: 7 new tests for abort behaviour + prompt content