### PR TITLE
fix: scope ABORT_JOB to nudge retries and serialise concurrent agent_end calls

### DIFF
--- a/src/lib/server/job-poller.test.ts
+++ b/src/lib/server/job-poller.test.ts
@@ -276,14 +276,15 @@ describe('job-poller', () => {
 	});
 
 	describe('handleJobAgentEnd — ABORT_JOB', () => {
-		it('immediately fails a running review job when ABORT_JOB is present', async () => {
+		it('immediately fails a running review job during nudge retry when ABORT_JOB is present', async () => {
 			const job = createTestJob({
 				type: 'review',
 				title: 'Review missing PR',
 				repo: '/repo',
 				pr_url: 'https://github.com/org/repo/pull/404',
 			});
-			updateJobStatus(job.id, { status: 'running', session_id: 'test-session' });
+			// Simulate being in a nudge retry (no_verdict_retries > 0)
+			updateJobStatus(job.id, { status: 'running', session_id: 'test-session', no_verdict_retries: 1 });
 
 			await handleJobAgentEnd(job.id, 'The PR does not exist.\nABORT_JOB: PR not found - repository returned 404');
 
@@ -293,13 +294,13 @@ describe('job-poller', () => {
 			expect(updated.error).toContain('PR not found');
 		});
 
-		it('immediately fails a reviewing-phase job when ABORT_JOB is present', async () => {
+		it('immediately fails a reviewing-phase job during nudge retry when ABORT_JOB is present', async () => {
 			const job = createTestJob({
 				title: 'Task with bad repo',
 				repo: '/repo',
 				max_loops: 3,
 			});
-			updateJobStatus(job.id, { status: 'reviewing', session_id: 'test-session' });
+			updateJobStatus(job.id, { status: 'reviewing', session_id: 'test-session', no_verdict_retries: 2 });
 
 			await handleJobAgentEnd(job.id, 'Cannot find the repo.\nABORT_JOB: Repository does not exist');
 
@@ -309,13 +310,13 @@ describe('job-poller', () => {
 			expect(updated.error).toContain('Repository does not exist');
 		});
 
-		it('ABORT_JOB takes precedence over VERDICT marker', async () => {
+		it('ABORT_JOB takes precedence over VERDICT marker during nudge retry', async () => {
 			const job = createTestJob({
 				type: 'review',
 				title: 'Conflicting markers',
 				repo: '/repo',
 			});
-			updateJobStatus(job.id, { status: 'running', session_id: 'test-session' });
+			updateJobStatus(job.id, { status: 'running', session_id: 'test-session', no_verdict_retries: 1 });
 
 			await handleJobAgentEnd(job.id, 'VERDICT: approved\nABORT_JOB: Something is fundamentally wrong');
 
@@ -324,21 +325,39 @@ describe('job-poller', () => {
 			expect(updated.error).toContain('Aborted by agent');
 		});
 
-		it('ABORT_JOB skips nudge retries entirely', async () => {
+		it('ABORT_JOB skips remaining nudge retries', async () => {
 			const job = createTestJob({
 				type: 'review',
-				title: 'Skip nudges',
+				title: 'Skip remaining nudges',
 				repo: '/repo',
 			});
-			// Still has nudge retries available
-			updateJobStatus(job.id, { status: 'running', session_id: 'test-session', no_verdict_retries: 0 });
+			// First nudge was sent, still has retries remaining
+			updateJobStatus(job.id, { status: 'running', session_id: 'test-session', no_verdict_retries: 1 });
 
 			await handleJobAgentEnd(job.id, 'ABORT_JOB: Issue cannot be found');
 
 			const updated = getJob(job.id)!;
 			expect(updated.status).toBe('failed');
-			// no_verdict_retries should not have been incremented
-			expect(updated.no_verdict_retries).toBe(0);
+			// no_verdict_retries should not have been incremented further
+			expect(updated.no_verdict_retries).toBe(1);
+		});
+
+		it('ignores ABORT_JOB during normal runs (no_verdict_retries is 0)', async () => {
+			const job = createTestJob({
+				type: 'review',
+				title: 'Normal run with ABORT_JOB in text',
+				repo: '/repo',
+				pr_url: 'https://github.com/org/repo/pull/42',
+			});
+			updateJobStatus(job.id, { status: 'running', session_id: 'test-session' });
+
+			// Agent happens to mention ABORT_JOB but also gives a verdict
+			await handleJobAgentEnd(job.id, 'ABORT_JOB: this text should be ignored\nVERDICT: approved');
+
+			const updated = getJob(job.id)!;
+			// Should process normally — ABORT_JOB ignored, verdict honoured
+			expect(updated.status).toBe('done');
+			expect(updated.review_verdict).toBe('approved');
 		});
 
 		it('does not abort for terminal-state jobs', async () => {
@@ -351,6 +370,31 @@ describe('job-poller', () => {
 			await handleJobAgentEnd(job.id, 'ABORT_JOB: Too late');
 
 			expect(getJob(job.id)!.status).toBe('done');
+		});
+	});
+
+	describe('handleJobAgentEnd — concurrency', () => {
+		it('serialises concurrent calls so a late empty-text call does not spuriously nudge', async () => {
+			const job = createTestJob({
+				type: 'review',
+				title: 'Race condition test',
+				repo: '/repo',
+				pr_url: 'https://github.com/org/repo/pull/99',
+			});
+			updateJobStatus(job.id, { status: 'running', session_id: 'test-session' });
+
+			// Fire two concurrent calls: one with a verdict, one with empty text
+			// (simulates agent_end + session_ended racing)
+			const call1 = handleJobAgentEnd(job.id, 'Looks good!\nVERDICT: approved');
+			const call2 = handleJobAgentEnd(job.id, '');
+
+			await Promise.all([call1, call2]);
+
+			const updated = getJob(job.id)!;
+			// Should be done (from the first call), not failed/nudged by the second
+			expect(updated.status).toBe('done');
+			expect(updated.review_verdict).toBe('approved');
+			expect(updated.no_verdict_retries).toBe(0);
 		});
 	});
 

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -37,6 +37,14 @@ let isPolling = false;
 /** Active session subscriptions keyed by job ID — used to unsubscribe on cleanup. */
 const sessionUnsubscribers = new Map<string, () => void>();
 
+/**
+ * Per-job lock to serialise handleJobAgentEnd calls. Prevents race conditions
+ * where concurrent agent_end / session_ended events both read the job status
+ * before either has written, causing duplicate state transitions (e.g. a
+ * spurious nudge after a verdict was already processed).
+ */
+const jobLocks = new Map<string, Promise<void>>();
+
 // --- Public API ---
 
 /**
@@ -268,6 +276,14 @@ function extractVerdict(
  * - reviewing → running (changes_requested): send fix prompt or done if loop cap reached
  */
 export async function handleJobAgentEnd(jobId: string, assistantText: string): Promise<void> {
+	// Serialise concurrent calls for the same job to prevent race conditions
+	const prev = jobLocks.get(jobId) ?? Promise.resolve();
+	const current = prev.then(() => _handleJobAgentEndInner(jobId, assistantText));
+	jobLocks.set(jobId, current.catch(() => {}));
+	return current;
+}
+
+async function _handleJobAgentEndInner(jobId: string, assistantText: string): Promise<void> {
 	try {
 		// Re-fetch the job to check current status
 		const job = getJob(jobId);
@@ -286,8 +302,12 @@ export async function handleJobAgentEnd(jobId: string, assistantText: string): P
 		const prUrlMatch = assistantText.match(PR_URL_PATTERN);
 		const verdictMatch = assistantText.match(VERDICT_PATTERN);
 
-		// Check for agent-initiated abort (unrecoverable error)
-		const abortMatch = assistantText.match(ABORT_JOB_PATTERN);
+		// Check for agent-initiated abort — only honoured during nudge retries
+		// (the agent is only told about ABORT_JOB in the nudge prompt, so we
+		// ignore it in normal runs to avoid false positives).
+		const abortMatch = job.no_verdict_retries > 0
+			? assistantText.match(ABORT_JOB_PATTERN)
+			: null;
 
 		log.info('job-poller', `agent_end for job ${jobId} (status=${job.status}) — prUrl=${prUrlMatch?.[1] ?? 'none'}, verdict=${verdictMatch?.[1] ?? 'none'}, abort=${abortMatch ? 'yes' : 'no'}`);
 


### PR DESCRIPTION
## Problem
A session that **did** send a valid VERDICT was still getting nudged. This was caused by two issues:

### 1. Race condition in concurrent `handleJobAgentEnd` calls
The subscription's `agent_end` and `session_ended` events can fire near-simultaneously. Both calls read the job status before either writes, so the second call (with empty text) sees the job still in `reviewing` and triggers a spurious nudge.

### 2. `ABORT_JOB` detection was too broad
It ran on every `agent_end`, not just during nudge retries. If the agent text organically contained `ABORT_JOB:` during a normal run, it would false-positive.

## Solution

### Per-job serialisation lock
Added a `jobLocks` map that chains promises per job ID. Concurrent `handleJobAgentEnd` calls for the same job are serialised — the second call waits for the first to complete, then re-fetches the job and sees the terminal state.

### Scoped ABORT_JOB
`ABORT_JOB` pattern is only matched when `no_verdict_retries > 0` (the agent has been nudged and knows about the marker).

## Tests
- Race condition test: two concurrent calls (one with verdict, one empty) → job ends up `done`, not nudged
- ABORT_JOB ignored during normal runs
- Updated existing ABORT_JOB tests to set `no_verdict_retries > 0`