### PR TITLE
fix: instruct review agent to submit verdict to GitHub PR

### DIFF
--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -29,6 +29,9 @@ const VERDICT_FALLBACK_CHANGES = /\b(?:gh pr review \d+ --request-changes|reques
 /** Pattern for the agent to signal an unrecoverable error and abort the job. */
 const ABORT_JOB_PATTERN = /ABORT_JOB:\s*(.+)/;
 
+/** Pattern for the agent to signal that gh pr review submission failed. */
+const REVIEW_SUBMIT_FAILED_PATTERN = /REVIEW_SUBMIT_FAILED:\s*(.+)/;
+
 // --- State ---
 
 let pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -250,7 +253,9 @@ async function _handleJobAgentEndInner(jobId: string, assistantText: string): Pr
 			? assistantText.match(ABORT_JOB_PATTERN)
 			: null;
 
-		log.info('job-poller', `agent_end for job ${jobId} (status=${job.status}) — prUrl=${prUrlMatch?.[1] ?? 'none'}, verdict=${verdictMatch?.[1] ?? 'none'}, abort=${abortMatch ? 'yes' : 'no'}`);
+		const reviewSubmitFailed = assistantText.match(REVIEW_SUBMIT_FAILED_PATTERN);
+
+		log.info('job-poller', `agent_end for job ${jobId} (status=${job.status}) — prUrl=${prUrlMatch?.[1] ?? 'none'}, verdict=${verdictMatch?.[1] ?? 'none'}, abort=${abortMatch ? 'yes' : 'no'}, reviewSubmitFailed=${reviewSubmitFailed ? 'yes' : 'no'}`);
 
 		// ABORT_JOB short-circuits all state transitions — fail immediately
 		if (abortMatch) {
@@ -270,6 +275,18 @@ async function _handleJobAgentEndInner(jobId: string, assistantText: string): Pr
 			// Review-type jobs: dispatched with a review prompt, so agent_end
 			// means the review is complete. Extract the verdict and finish.
 			if (job.type === 'review') {
+				// If the agent reported that gh pr review failed, fail the job
+				if (reviewSubmitFailed) {
+					const reason = reviewSubmitFailed[1].trim();
+					log.warn('job-poller', `review job ${jobId} — gh pr review submission failed: ${reason}`);
+					updateJobStatus(jobId, {
+						status: 'failed',
+						error: `Review submission to GitHub failed: ${reason}`,
+					});
+					await stopJobSession(job);
+					return;
+				}
+
 				const verdict = extractVerdict(assistantText, verdictMatch);
 				if (verdict) {
 					updateJobStatus(jobId, {
@@ -331,6 +348,18 @@ async function _handleJobAgentEndInner(jobId: string, assistantText: string): Pr
 			// The user manually reviews the PR and marks the job done via the dashboard.
 			if (job.max_loops === 0) {
 				log.info('job-poller', `agent_end for fire-and-forget job ${jobId} in reviewing — ignoring (manual review only)`);
+				return;
+			}
+
+			// If the agent reported that gh pr review failed, fail the job
+			if (reviewSubmitFailed) {
+				const reason = reviewSubmitFailed[1].trim();
+				log.warn('job-poller', `job ${jobId} — gh pr review submission failed during review phase: ${reason}`);
+				updateJobStatus(jobId, {
+					status: 'failed',
+					error: `Review submission to GitHub failed: ${reason}`,
+				});
+				await stopJobSession(job);
 				return;
 			}
 

--- a/src/lib/server/job-prompts.ts
+++ b/src/lib/server/job-prompts.ts
@@ -139,13 +139,21 @@ export function buildReviewPrompt(job: Job, harness: string = 'pi'): string {
 	}
 
 	parts.push('');
-	parts.push('=== CRITICAL: REQUIRED OUTPUT ===');
-	parts.push('After completing the review, you MUST output EXACTLY one of these two lines as the VERY LAST thing in your response:');
+	parts.push('=== CRITICAL: REQUIRED STEPS ===');
+	parts.push('After completing the review, you MUST do BOTH of these steps:');
+	parts.push('');
+	parts.push('1. SUBMIT the review to GitHub using gh pr review:');
+	parts.push('   - Approve: gh pr review <number> --approve --body "your review summary"');
+	parts.push('   - Request changes: gh pr review <number> --request-changes --body "your review summary"');
+	parts.push('   Include your review summary (strengths, issues, suggestions) in the --body.');
+	parts.push('   Do NOT skip this step. The review MUST be visible on the GitHub PR.');
+	parts.push('');
+	parts.push('2. THEN output EXACTLY one of these two lines as the VERY LAST thing in your response:');
 	parts.push('');
 	parts.push('VERDICT: approved');
 	parts.push('VERDICT: changes_requested');
 	parts.push('');
-	parts.push('This is a machine-parsed marker. The job will FAIL if you do not include it.');
+	parts.push('The VERDICT line is a machine-parsed marker. The job will FAIL if you do not include it.');
 	parts.push('Do NOT paraphrase, reword, or wrap it in a code block. Output the exact line on its own.');
 	parts.push('=================================');
 

--- a/src/lib/server/job-prompts.ts
+++ b/src/lib/server/job-prompts.ts
@@ -140,7 +140,7 @@ export function buildReviewPrompt(job: Job, harness: string = 'pi'): string {
 
 	parts.push('');
 	parts.push('=== CRITICAL: REQUIRED STEPS ===');
-	parts.push('After completing the review, you MUST do BOTH of these steps:');
+	parts.push('After completing the review, you MUST do BOTH of these steps IN ORDER:');
 	parts.push('');
 	parts.push('1. SUBMIT the review to GitHub using gh pr review:');
 	parts.push('   - Approve: gh pr review <number> --approve --body "your review summary"');
@@ -148,13 +148,18 @@ export function buildReviewPrompt(job: Job, harness: string = 'pi'): string {
 	parts.push('   Include your review summary (strengths, issues, suggestions) in the --body.');
 	parts.push('   Do NOT skip this step. The review MUST be visible on the GitHub PR.');
 	parts.push('');
-	parts.push('2. THEN output EXACTLY one of these two lines as the VERY LAST thing in your response:');
+	parts.push('2. Check that the gh pr review command succeeded. ONLY if it succeeded,');
+	parts.push('   output EXACTLY one of these two lines as the VERY LAST thing in your response:');
 	parts.push('');
 	parts.push('VERDICT: approved');
 	parts.push('VERDICT: changes_requested');
 	parts.push('');
-	parts.push('The VERDICT line is a machine-parsed marker. The job will FAIL if you do not include it.');
-	parts.push('Do NOT paraphrase, reword, or wrap it in a code block. Output the exact line on its own.');
+	parts.push('If the gh pr review command FAILED (non-zero exit, error output, permission denied),');
+	parts.push('do NOT output a VERDICT line. Instead output:');
+	parts.push('');
+	parts.push('REVIEW_SUBMIT_FAILED: <reason>');
+	parts.push('');
+	parts.push('These are machine-parsed markers. Do NOT paraphrase, reword, or wrap in a code block.');
 	parts.push('=================================');
 
 	return parts.join('\n');


### PR DESCRIPTION
## Summary

- Updated `buildReviewPrompt()` to explicitly instruct the agent to submit the review to GitHub via `gh pr review` before outputting the `VERDICT:` marker
- Previously the prompt only asked for a text marker, so the agent produced great reviews in chat but never ran `gh pr review --approve` / `--request-changes`

## Test plan

- [ ] Typecheck passes (`npx tsc --noEmit`)
- [ ] Existing tests pass (`npm test`)
- [ ] Trigger a review job and verify the review appears on the GitHub PR (not just in chat)

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Review prompts now require performing a GitHub PR review action before emitting a final verdict.

* **Bug Fixes**
  * Worker now detects when review submission fails and marks the review job as failed immediately, stopping further review progress or retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->