### PR TITLE
chore: add agent setup guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,7 @@ Open [http://localhost:4020](http://localhost:4020) in your browser.
 
 ## Environment Variables
 
-| Variable           | Default     | Description                                                            |
-| ------------------ | ----------- | ---------------------------------------------------------------------- |
-| `PI_BIN`           | `pi`        | Path to the Pi binary                                                  |
-| `PORT`             | `3000`      | Port for the standalone server                                         |
-| `HOST`             | `0.0.0.0`  | Host for the standalone server                                         |
-| `PI_AUTH_PASSWORD`  | _(unset)_   | Password to protect the dashboard. Supports plaintext or bcrypt hash.  |
+See [Agent Setup § Environment Configuration](#3-environment-configuration) for the full env var reference.
 
 ### Authentication
 
@@ -95,6 +90,13 @@ cp .env.example .env
 ```
 
 Edit `.env` and set values as needed. All variables are optional and have sensible defaults:
+
+**Server (standalone/production only — dev server always uses port 4020):**
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `4020` | Port for the standalone/production server |
+| `HOST` | `0.0.0.0` | Host to bind the standalone/production server |
 
 **Authentication:**
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,132 @@ bun -e "console.log(await Bun.password.hash('my-secret', { algorithm: 'bcrypt' }
 Job completion callbacks (`/api/jobs/:id/complete`) are exempt — they use their
 own per-job token authentication.
 
+## Agent Setup
+
+Step-by-step instructions for an AI coding agent to set up the project from scratch.
+
+### 1. Prerequisites Check
+
+Verify the following are available on `PATH`:
+
+```sh
+bun --version        # Bun ≥ 1.0
+gh auth status       # GitHub CLI, authenticated
+pi --version         # Pi coding agent (or claude --version for Claude Code)
+```
+
+### 2. Install & Build
+
+```sh
+bun install
+bun run check        # typecheck
+bun test src/        # unit tests
+```
+
+### 3. Environment Configuration
+
+```sh
+cp .env.example .env
+```
+
+Edit `.env` and set values as needed. All variables are optional and have sensible defaults:
+
+**Authentication:**
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PI_AUTH_PASSWORD` | _(unset)_ | Password to protect the dashboard (plaintext or bcrypt hash) |
+
+**Harness:**
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PI_HARNESS` | `pi` | Coding harness: `pi` or `claude-code` |
+| `PI_BIN` | `pi` | Path to the Pi binary |
+| `CLAUDE_BIN` | `claude` | Path to the Claude Code binary |
+
+**Sessions:**
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PI_SESSIONS_DIR` | `~/.pi/agent/sessions` | Session storage directory |
+
+**Jobs & Worktrees:**
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PI_WORKTREE_DIR` | `.worktrees` | Worktree directory for job isolation (relative to project) |
+| `PI_REMOTE_HOST` | _(auto-detected)_ | Host/origin for job completion callbacks |
+
+**Job Skills:**
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PI_JOB_TASK_SKILL` | _(unset)_ | Skill for fire-and-forget tasks (`max_loops=0`) |
+| `PI_JOB_LOOP_TASK_SKILL` | _(unset)_ | Skill for the task/fix phase inside a review loop (`max_loops>0`) |
+| `PI_JOB_REVIEW_SKILL` | _(unset)_ | Skill for the review phase inside a review loop |
+
+**PR Poller:**
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PI_PR_POLL_INTERVAL_SECONDS` | `600` | Polling interval in seconds (10 minutes) |
+| `PI_PR_POLL_CONCURRENCY` | `5` | Max concurrent running jobs |
+
+### 4. Extension Setup
+
+Symlink the job-callback extension into Pi's extensions directory:
+
+```sh
+bash scripts/setup-hooks.sh
+```
+
+This symlinks `extensions/job-callback.ts` into `~/.pi/agent/extensions/`. The extension fires on `agent_end` to report job results (success/failure) back to pi-remote-web via its callback API.
+
+### 5. Running
+
+```sh
+# Development (port 4020)
+bun run dev
+
+# Production
+bun run build && bun run preview
+
+# Standalone binary
+bun run package && ./dist/pi-dashboard
+```
+
+### 6. Adding Monitored Repos (PR Poller)
+
+The PR poller watches GitHub repos for pull requests and automatically dispatches review jobs. Manage monitored repos via the API:
+
+```sh
+# List monitored repos
+curl http://localhost:4020/api/monitored-repos
+
+# Add a repo
+curl -X POST http://localhost:4020/api/monitored-repos \
+  -H 'Content-Type: application/json' \
+  -d '{"owner": "org", "repo": "my-repo", "enabled": true, "assigned_only": false, "manual_only": false}'
+```
+
+Per-repo toggles:
+
+- `enabled` — whether the poller watches this repo
+- `assigned_only` — only poll PRs assigned to the authenticated GitHub user
+- `manual_only` — skip automatic polling; only process PRs triggered manually
+
+### 7. Development Workflow
+
+```sh
+bun run check        # typecheck before committing
+bun test src/        # run tests before committing
+```
+
+- Use conventional commits (e.g. `feat:`, `fix:`, `chore:`)
+- Use Australian English in user-facing copy
+- Work on feature branches; open PRs against `main`
+
 ## Scripts
 
 | Command              | Description                                      |


### PR DESCRIPTION
## Summary

- Add a new **Agent Setup** section to `README.md` with step-by-step instructions for AI coding agents to bootstrap the project from scratch
- Documents all env vars from `.env.example` in categorised tables (auth, harness, sessions, jobs, PR poller)
- Covers prerequisites, install/build, environment config, extension setup, running, monitored repos, and development workflow

Closes #58

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all env vars from `.env.example` are documented
- [ ] Confirm existing README sections are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive agent setup with prerequisites, install/build/test and .env creation
  * Expanded environment configuration into grouped subsections (Server, Authentication, Harness, Sessions, Jobs, Skills, PR Poller) and updated defaults (e.g., PORT = 4020)
  * Documented extension hook setup and callback behavior
  * Added run instructions for development, production, and standalone packaging
  * Added PR poller operational docs with API examples and repo toggle semantics
  * Added contributor workflow and pre-commit guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->