### PR TITLE
feat: rework PR review triggers and timebox stale PR search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,5 +38,10 @@
 # Max concurrent running jobs (default: 5)
 # PI_PR_POLL_CONCURRENCY=5
 
+# Max age of PRs (in days) to consider when a monitored repo has assigned_only
+# disabled. PRs created before this cutoff are skipped. Ignored when
+# assigned_only is on. (default: 30)
+# PI_PR_MAX_AGE_DAYS=30
+
 # Allow additional server hosts
 # __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS

--- a/src/lib/server/cache.ts
+++ b/src/lib/server/cache.ts
@@ -191,6 +191,12 @@ export function getDb(): Database {
 
 		db.run('CREATE INDEX IF NOT EXISTS idx_monitored_repos_enabled ON monitored_repos(enabled)');
 
+		db.run(`CREATE TABLE IF NOT EXISTS pr_review_state (
+			pr_url TEXT PRIMARY KEY,
+			last_reviewed_head_sha TEXT NOT NULL,
+			last_reviewed_at TEXT NOT NULL
+		)`);
+
 		db.run('CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status)');
 		db.run('CREATE INDEX IF NOT EXISTS idx_jobs_type ON jobs(type)');
 		db.run('CREATE INDEX IF NOT EXISTS idx_jobs_parent ON jobs(parent_job_id)');

--- a/src/lib/server/github-pr-poller.test.ts
+++ b/src/lib/server/github-pr-poller.test.ts
@@ -11,6 +11,9 @@ import {
 	_resetForTesting,
 	getPollIntervalMs,
 	getConcurrency,
+	getPrMaxAgeDays,
+	getPrReviewState,
+	upsertPrReviewState,
 	getGitHubUser,
 	listOpenPrs,
 	scanRepos,
@@ -267,6 +270,87 @@ describe('github-pr-poller', () => {
 			} else {
 				delete process.env.PI_PR_POLL_CONCURRENCY;
 			}
+		});
+
+		it('returns default PR max age (30 days) when env is unset', () => {
+			const original = process.env.PI_PR_MAX_AGE_DAYS;
+			delete process.env.PI_PR_MAX_AGE_DAYS;
+
+			expect(getPrMaxAgeDays()).toBe(30);
+
+			if (original !== undefined) process.env.PI_PR_MAX_AGE_DAYS = original;
+		});
+
+		it('reads PR max age from env', () => {
+			const original = process.env.PI_PR_MAX_AGE_DAYS;
+			process.env.PI_PR_MAX_AGE_DAYS = '7';
+
+			expect(getPrMaxAgeDays()).toBe(7);
+
+			if (original !== undefined) {
+				process.env.PI_PR_MAX_AGE_DAYS = original;
+			} else {
+				delete process.env.PI_PR_MAX_AGE_DAYS;
+			}
+		});
+
+		it('falls back to default for invalid PR max age', () => {
+			const original = process.env.PI_PR_MAX_AGE_DAYS;
+			process.env.PI_PR_MAX_AGE_DAYS = 'not-a-number';
+
+			expect(getPrMaxAgeDays()).toBe(30);
+
+			if (original !== undefined) {
+				process.env.PI_PR_MAX_AGE_DAYS = original;
+			} else {
+				delete process.env.PI_PR_MAX_AGE_DAYS;
+			}
+		});
+
+		it('rejects zero or negative PR max age', () => {
+			const original = process.env.PI_PR_MAX_AGE_DAYS;
+			process.env.PI_PR_MAX_AGE_DAYS = '0';
+			expect(getPrMaxAgeDays()).toBe(30);
+			process.env.PI_PR_MAX_AGE_DAYS = '-5';
+			expect(getPrMaxAgeDays()).toBe(30);
+
+			if (original !== undefined) {
+				process.env.PI_PR_MAX_AGE_DAYS = original;
+			} else {
+				delete process.env.PI_PR_MAX_AGE_DAYS;
+			}
+		});
+	});
+
+	describe('pr review state persistence', () => {
+		const TEST_PR_URL = 'https://github.com/acme/test-state/pull/999';
+		const CLEANUP_URLS: string[] = [TEST_PR_URL];
+
+		afterEach(() => {
+			const db = getDb();
+			for (const url of CLEANUP_URLS) {
+				db.run('DELETE FROM pr_review_state WHERE pr_url = ?', [url]);
+			}
+		});
+
+		it('returns null for unknown PR URLs', () => {
+			expect(getPrReviewState('https://github.com/acme/nope/pull/1')).toBeNull();
+		});
+
+		it('upserts and reads back review state', () => {
+			upsertPrReviewState(TEST_PR_URL, 'deadbeef', '2026-04-01T10:00:00Z');
+			const state = getPrReviewState(TEST_PR_URL);
+			expect(state).not.toBeNull();
+			expect(state!.last_reviewed_head_sha).toBe('deadbeef');
+			expect(state!.last_reviewed_at).toBe('2026-04-01T10:00:00Z');
+		});
+
+		it('upsert overwrites existing state', () => {
+			upsertPrReviewState(TEST_PR_URL, 'sha-one', '2026-04-01T10:00:00Z');
+			upsertPrReviewState(TEST_PR_URL, 'sha-two', '2026-04-02T10:00:00Z');
+			const state = getPrReviewState(TEST_PR_URL);
+			expect(state!.last_reviewed_head_sha).toBe('sha-two');
+			expect(state!.last_reviewed_at).toBe('2026-04-02T10:00:00Z');
 		});
 	});
 });

--- a/src/lib/server/github-pr-poller.ts
+++ b/src/lib/server/github-pr-poller.ts
@@ -7,9 +7,15 @@
  *   - manual_only: skip during automatic polling, only check on manual trigger (default: on)
  *   - enabled: master toggle (default: on)
  *
+ * Per-PR review state is tracked in the `pr_review_state` table so we can
+ * detect whether there are new commits or new author comments since our
+ * last review job.
+ *
  * Configuration via environment:
  *   PI_PR_POLL_INTERVAL_SECONDS — polling interval (default: 600 = 10 minutes)
  *   PI_PR_POLL_CONCURRENCY — max concurrent running jobs (default: 5)
+ *   PI_PR_MAX_AGE_DAYS — only consider PRs created within this many days when
+ *     assigned_only is off (default: 30). Ignored when assigned_only is on.
  */
 import { getDb } from './cache';
 import { createJob, findActiveJobByPrUrl } from './job-queue';
@@ -21,6 +27,7 @@ import { log } from './logger';
 
 const DEFAULT_POLL_INTERVAL_SECONDS = 600;
 const DEFAULT_CONCURRENCY = 5;
+const DEFAULT_PR_MAX_AGE_DAYS = 30;
 const GH_TIMEOUT_MS = 15_000;
 
 /** Per-PR error backoff: skip PRs that have failed review-state checks recently. */
@@ -64,9 +71,15 @@ interface GitHubPr {
 	number: number;
 	title: string;
 	headRefName: string;
+	headRefOid: string;
 	baseRefName: string;
 	url: string;
 	author?: { login: string };
+}
+
+export interface PrReviewState {
+	last_reviewed_head_sha: string;
+	last_reviewed_at: string;
 }
 
 // --- Configuration ---
@@ -79,6 +92,32 @@ export function getPollIntervalMs(): number {
 export function getConcurrency(): number {
 	const val = parseInt(process.env.PI_PR_POLL_CONCURRENCY ?? '', 10);
 	return Number.isFinite(val) && val > 0 ? val : DEFAULT_CONCURRENCY;
+}
+
+export function getPrMaxAgeDays(): number {
+	const val = parseInt(process.env.PI_PR_MAX_AGE_DAYS ?? '', 10);
+	return Number.isFinite(val) && val > 0 ? val : DEFAULT_PR_MAX_AGE_DAYS;
+}
+
+// --- PR review state persistence ---
+
+/** Look up the last review we ran for a given PR URL. */
+export function getPrReviewState(prUrl: string): PrReviewState | null {
+	return getDb().query(
+		'SELECT last_reviewed_head_sha, last_reviewed_at FROM pr_review_state WHERE pr_url = ?'
+	).get(prUrl) as PrReviewState | null;
+}
+
+/** Record that we just ran (or are about to run) a review for a PR. */
+export function upsertPrReviewState(prUrl: string, headSha: string, reviewedAt: string): void {
+	getDb().run(
+		`INSERT INTO pr_review_state (pr_url, last_reviewed_head_sha, last_reviewed_at)
+		 VALUES (?, ?, ?)
+		 ON CONFLICT(pr_url) DO UPDATE SET
+		   last_reviewed_head_sha = excluded.last_reviewed_head_sha,
+		   last_reviewed_at = excluded.last_reviewed_at`,
+		[prUrl, headSha, reviewedAt]
+	);
 }
 
 // --- State ---
@@ -212,6 +251,10 @@ export async function getGitHubUser(): Promise<string | null> {
 
 /**
  * List open PRs for a given repo. Optionally filter by assignee.
+ *
+ * When `assignee` is not provided, the result is timeboxed to PRs created
+ * within the last `PI_PR_MAX_AGE_DAYS` days (default 30) to avoid spinning
+ * up reviews on stale PRs in busy repos.
  */
 export async function listOpenPrs(owner: string, name: string, assignee?: string, excludeAuthor?: string): Promise<GitHubPr[]> {
 	try {
@@ -219,12 +262,18 @@ export async function listOpenPrs(owner: string, name: string, assignee?: string
 			'pr', 'list',
 			'--repo', `${owner}/${name}`,
 			'--state', 'open',
-			'--json', 'number,title,headRefName,baseRefName,url,isDraft,author',
+			'--json', 'number,title,headRefName,headRefOid,baseRefName,url,isDraft,author',
 			'--limit', '30',
 		];
 
 		if (assignee) {
 			args.push('--assignee', assignee);
+		} else {
+			// Timebox unfiltered searches so we don't review stale PRs.
+			const maxAgeDays = getPrMaxAgeDays();
+			const cutoff = new Date(Date.now() - maxAgeDays * 24 * 60 * 60 * 1000);
+			const cutoffStr = cutoff.toISOString().slice(0, 10); // YYYY-MM-DD
+			args.push('--search', `created:>=${cutoffStr}`);
 		}
 
 		const output = await execGh(args);
@@ -260,14 +309,6 @@ export async function listOpenPrs(owner: string, name: string, assignee?: string
 // gh pr list returns login as 'app/snyk-io' for GitHub Apps, not 'snyk-io[bot]'
 const BOT_LOGIN_PATTERNS = ['dependabot', 'snyk-io', 'renovate', 'github-actions'];
 
-// --- Dismiss keywords: if the last non-author comment contains one, skip ---
-const DISMISS_KEYWORDS = [
-	'approve', 'lgtm', 'ship it', 'shipit', 'looks good',
-	'needs work', 'needs changes', 'changes requested',
-	'wip', 'work in progress', 'not ready',
-	'hold off', "don't merge", 'do not merge', '+1',
-];
-
 /**
  * Parse NDJSON output from `gh api --paginate --jq`.
  *
@@ -287,109 +328,61 @@ function parseNdjson<T>(raw: string): T[] {
 		}) as T[];
 }
 
-/** A timestamped review event (from PR reviews API). */
-interface ReviewEvent {
-	type: 'review';
-	user: string;
-	state: string;
-	timestamp: string; // submitted_at
-}
-
-/** A timestamped comment event (from issue comments API). */
-interface CommentEvent {
-	type: 'comment';
-	user: string;
-	body: string;
-	timestamp: string; // created_at
-}
-
-type PrEvent = ReviewEvent | CommentEvent;
-
 /**
- * Check whether a PR needs review by inspecting its review state and comments.
+ * Decide whether a PR needs a (re-)review.
  *
- * Uses `--paginate` to fetch the full history for both reviews and comments,
- * then determines the single most-recent activity by comparing timestamps.
- * Decision logic is based on the true latest event across both lists.
+ * Triggers iff:
+ *   - PR is not self-authored AND
+ *     - we have no prior review state for it (brand-new PR), OR
+ *     - the PR's head SHA has changed since our last review (new commits), OR
+ *     - the PR author has commented since our last review
  *
- * Returns { shouldReview: boolean, reason: string }.
+ * Callers are responsible for skipping drafts and PRs with an active job.
  */
-export async function shouldReviewPr(owner: string, name: string, prNumber: number, prAuthor: string, ghUser: string): Promise<{ shouldReview: boolean; reason: string }> {
+export async function shouldReviewPr(
+	owner: string,
+	name: string,
+	prNumber: number,
+	prAuthor: string,
+	ghUser: string,
+	headSha: string,
+	priorState: PrReviewState | null
+): Promise<{ shouldReview: boolean; reason: string }> {
 	// Belt-and-suspenders: never review your own PRs
 	if (prAuthor && prAuthor.toLowerCase() === ghUser.toLowerCase()) {
 		return { shouldReview: false, reason: `self-authored by ${prAuthor}` };
 	}
 
+	// Brand-new PR — no prior state
+	if (!priorState) {
+		return { shouldReview: true, reason: 'new PR — needs review' };
+	}
+
+	// New commits pushed since last review
+	if (headSha && headSha !== priorState.last_reviewed_head_sha) {
+		return { shouldReview: true, reason: `new commits since last review (${priorState.last_reviewed_head_sha.slice(0, 7)} → ${headSha.slice(0, 7)})` };
+	}
+
+	// Check for new author comments since last review
 	try {
-		// Fetch ALL reviews and comments concurrently (paginated).
-		// Neither API supports sort/direction, so we paginate to get
-		// everything and sort client-side by timestamp.
-		const [reviewsJson, commentsJson] = await Promise.all([
-			execGh([
-				'api', '--paginate',
-				`repos/${owner}/${name}/pulls/${prNumber}/reviews`,
-				'--jq', '[.[] | select(.state != "DISMISSED" and .state != "PENDING") | {user: .user.login, state: .state, submitted_at: .submitted_at}]',
-			]),
-			execGh([
-				'api', '--paginate',
-				`repos/${owner}/${name}/issues/${prNumber}/comments`,
-				'--jq', '[.[] | select(.user.type != "Bot") | {user: .user.login, body: .body, created_at: .created_at}]',
-			]),
+		const commentsJson = await execGh([
+			'api', '--paginate',
+			`repos/${owner}/${name}/issues/${prNumber}/comments`,
+			'--jq', '[.[] | select(.user.type != "Bot") | {user: .user.login, created_at: .created_at}]',
 		]);
+		const comments = parseNdjson<{ user: string; created_at: string }>(commentsJson);
 
-		const rawReviews = parseNdjson<{ user: string; state: string; submitted_at: string }>(reviewsJson);
-		const reviews: ReviewEvent[] = rawReviews.map(r => ({
-			type: 'review' as const,
-			user: r.user,
-			state: r.state,
-			timestamp: r.submitted_at,
-		}));
+		const lastReviewedAt = new Date(priorState.last_reviewed_at).getTime();
+		const newerAuthorComment = comments.find(c =>
+			c.user.toLowerCase() === prAuthor.toLowerCase() &&
+			new Date(c.created_at).getTime() > lastReviewedAt
+		);
 
-		const rawComments = parseNdjson<{ user: string; body: string; created_at: string }>(commentsJson);
-		const comments: CommentEvent[] = rawComments.map(c => ({
-			type: 'comment' as const,
-			user: c.user,
-			body: c.body,
-			timestamp: c.created_at,
-		}));
-
-		// Merge and sort all events most-recent-first
-		const allEvents: PrEvent[] = [...reviews, ...comments]
-			.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
-
-		// No activity at all — brand new PR
-		if (allEvents.length === 0) {
-			return { shouldReview: true, reason: 'new PR — needs review' };
+		if (newerAuthorComment) {
+			return { shouldReview: true, reason: `author commented since last review (${newerAuthorComment.created_at})` };
 		}
 
-		const latest = allEvents[0];
-
-		// Decision based on the single most-recent event
-		if (latest.type === 'review') {
-			// Latest activity is a review
-			if (latest.state === 'APPROVED') {
-				return { shouldReview: false, reason: `already approved by ${latest.user}` };
-			}
-			if (latest.user.toLowerCase() === ghUser.toLowerCase()) {
-				return { shouldReview: false, reason: `last review is mine (${latest.state}) — waiting on author` };
-			}
-			// Someone else's non-approval review — may need attention
-			return { shouldReview: true, reason: `activity from ${latest.user} (${latest.state})` };
-		}
-
-		// Latest activity is a comment
-		if (latest.user.toLowerCase() === prAuthor.toLowerCase()) {
-			return { shouldReview: true, reason: 'author commented — re-review needed' };
-		}
-
-		// Non-author comment — check dismiss keywords
-		const lowerBody = (latest.body || '').toLowerCase();
-		const matched = DISMISS_KEYWORDS.find(kw => lowerBody.includes(kw));
-		if (matched) {
-			return { shouldReview: false, reason: `last comment by ${latest.user} contains "${matched}"` };
-		}
-		// Non-author commented without dismiss keyword — they're handling it
-		return { shouldReview: false, reason: `last comment by ${latest.user} (not PR author)` };
+		return { shouldReview: false, reason: 'no new commits or author comments since last review' };
 	} catch (err) {
 		log.error('github-pr-poller', `failed to check review state for ${owner}/${name}#${prNumber}: ${err}`);
 		// Fail closed — skip this PR and apply a per-PR backoff to avoid endless re-enqueueing
@@ -439,7 +432,10 @@ async function processPrs(
 		if (backoffExpiry) prErrorBackoff.delete(prKey); // expired — clean up
 
 		// Check review state — skip if already handled
-		const { shouldReview, reason } = await shouldReviewPr(repo.owner, repo.name, pr.number, prAuthor, ghUser);
+		const priorState = getPrReviewState(prUrl);
+		const { shouldReview, reason } = await shouldReviewPr(
+			repo.owner, repo.name, pr.number, prAuthor, ghUser, pr.headRefOid, priorState
+		);
 		if (!shouldReview) {
 			log.info('github-pr-poller', `skipping ${repo.owner}/${repo.name}#${pr.number} — ${reason}`);
 			result.skipped++;
@@ -460,6 +456,9 @@ async function processPrs(
 				review_skill: REVIEW_SKILL || undefined,
 				harness: getHarness(),
 			});
+			// Record that we kicked off a review so we don't re-trigger on the
+			// same head SHA or pre-existing author comments.
+			upsertPrReviewState(prUrl, pr.headRefOid, new Date().toISOString());
 			log.info('github-pr-poller', `created review job ${job.id} for ${repo.owner}/${repo.name}#${pr.number}`);
 			result.created++;
 		} catch (err) {

--- a/src/lib/server/shouldReviewPr.test.ts
+++ b/src/lib/server/shouldReviewPr.test.ts
@@ -11,9 +11,7 @@ let apiResponses: Map<string, string> = new Map();
 let spawnCalls: string[][] = [];
 
 // Patch Bun.spawn globally — execGh calls Bun.spawn(['gh', ...args], ...)
-const originalSpawn = Bun.spawn;
-
-function mockSpawn(cmd: string | string[], opts?: any): any {
+function mockSpawn(cmd: string | string[], _opts?: any): any {
 	const args = Array.isArray(cmd) ? cmd : [cmd];
 	// Record the gh args (skip the 'gh' binary itself)
 	if (args[0] === 'gh') {
@@ -57,6 +55,7 @@ mock.module('./logger', () => ({
 
 // Import after mocking
 const { shouldReviewPr } = await import('./github-pr-poller');
+type PrReviewState = import('./github-pr-poller').PrReviewState;
 
 // --- Helpers ---
 
@@ -65,21 +64,19 @@ const REPO = 'widget';
 const PR_NUM = 42;
 const PR_AUTHOR = 'alice';
 const GH_USER = 'bob';
-
-function reviewsEndpoint() {
-	return `repos/${OWNER}/${REPO}/pulls/${PR_NUM}/reviews`;
-}
+const SHA_A = 'aaaaaaa1111111111111111111111111111aaaaa';
+const SHA_B = 'bbbbbbb2222222222222222222222222222bbbbb';
 
 function commentsEndpoint() {
 	return `repos/${OWNER}/${REPO}/issues/${PR_NUM}/comments`;
 }
 
-function setReviews(reviews: Array<{ user: string; state: string; submitted_at: string }>) {
-	apiResponses.set(reviewsEndpoint(), JSON.stringify(reviews));
+function setComments(comments: Array<{ user: string; created_at: string }>) {
+	apiResponses.set(commentsEndpoint(), JSON.stringify(comments));
 }
 
-function setComments(comments: Array<{ user: string; body: string; created_at: string }>) {
-	apiResponses.set(commentsEndpoint(), JSON.stringify(comments));
+function state(sha: string, reviewedAt: string): PrReviewState {
+	return { last_reviewed_head_sha: sha, last_reviewed_at: reviewedAt };
 }
 
 describe('shouldReviewPr', () => {
@@ -89,193 +86,125 @@ describe('shouldReviewPr', () => {
 	});
 
 	it('skips self-authored PRs', async () => {
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, GH_USER, GH_USER);
+		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, GH_USER, GH_USER, SHA_A, null);
 		expect(result.shouldReview).toBe(false);
 		expect(result.reason).toContain('self-authored');
 	});
 
-	it('returns needs review for new PR with no activity', async () => {
-		setReviews([]);
-		setComments([]);
+	it('is case-insensitive for self-authored check', async () => {
+		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, 'Bob', 'bob', SHA_A, null);
+		expect(result.shouldReview).toBe(false);
+		expect(result.reason).toContain('self-authored');
+	});
 
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
+	it('triggers review when there is no prior state (new PR)', async () => {
+		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_A, null);
 		expect(result.shouldReview).toBe(true);
 		expect(result.reason).toContain('new PR');
 	});
 
-	it('skips when latest activity is an approval', async () => {
-		setReviews([
-			{ user: 'carol', state: 'CHANGES_REQUESTED', submitted_at: '2025-01-01T10:00:00Z' },
-			{ user: 'carol', state: 'APPROVED', submitted_at: '2025-01-01T12:00:00Z' },
-		]);
-		setComments([]);
-
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
-		expect(result.shouldReview).toBe(false);
-		expect(result.reason).toContain('approved');
-		expect(result.reason).toContain('carol');
+	it('does not fetch comments when there is no prior state', async () => {
+		await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_A, null);
+		// No gh calls should have been made — brand-new PR short-circuits
+		expect(spawnCalls.length).toBe(0);
 	});
 
-	it('skips when my review is the latest activity', async () => {
-		setReviews([
-			{ user: GH_USER, state: 'CHANGES_REQUESTED', submitted_at: '2025-01-01T12:00:00Z' },
-		]);
-		setComments([]);
-
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
-		expect(result.shouldReview).toBe(false);
-		expect(result.reason).toContain('last review is mine');
-		expect(result.reason).toContain('waiting on author');
+	it('triggers review when head SHA has changed (new commits)', async () => {
+		const prior = state(SHA_A, '2025-01-01T10:00:00Z');
+		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_B, prior);
+		expect(result.shouldReview).toBe(true);
+		expect(result.reason).toContain('new commits');
 	});
 
-	it('triggers re-review when author comments after my review', async () => {
-		setReviews([
-			{ user: GH_USER, state: 'CHANGES_REQUESTED', submitted_at: '2025-01-01T10:00:00Z' },
-		]);
+	it('does not fetch comments when head SHA has changed', async () => {
+		const prior = state(SHA_A, '2025-01-01T10:00:00Z');
+		await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_B, prior);
+		// SHA change short-circuits — no need to check comments
+		expect(spawnCalls.length).toBe(0);
+	});
+
+	it('triggers review when author has commented since last review', async () => {
 		setComments([
-			{ user: PR_AUTHOR, body: 'Fixed the issues', created_at: '2025-01-01T12:00:00Z' },
+			{ user: PR_AUTHOR, created_at: '2025-01-01T12:00:00Z' },
 		]);
-
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
+		const prior = state(SHA_A, '2025-01-01T10:00:00Z');
+		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_A, prior);
 		expect(result.shouldReview).toBe(true);
 		expect(result.reason).toContain('author commented');
 	});
 
-	it('skips when non-author comment contains dismiss keyword', async () => {
-		setReviews([]);
+	it('skips when author comment is older than last review', async () => {
 		setComments([
-			{ user: 'carol', body: 'LGTM, ship it!', created_at: '2025-01-01T12:00:00Z' },
+			{ user: PR_AUTHOR, created_at: '2025-01-01T08:00:00Z' },
 		]);
-
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
+		const prior = state(SHA_A, '2025-01-01T10:00:00Z');
+		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_A, prior);
 		expect(result.shouldReview).toBe(false);
-		expect(result.reason).toContain('lgtm');
+		expect(result.reason).toContain('no new commits or author comments');
 	});
 
-	it('skips when non-author comments without dismiss keyword', async () => {
-		setReviews([]);
+	it('skips when only non-author has commented since last review', async () => {
 		setComments([
-			{ user: 'carol', body: "I'll handle this review", created_at: '2025-01-01T12:00:00Z' },
+			{ user: 'carol', created_at: '2025-01-01T12:00:00Z' },
+			{ user: GH_USER, created_at: '2025-01-01T13:00:00Z' },
 		]);
-
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
+		const prior = state(SHA_A, '2025-01-01T10:00:00Z');
+		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_A, prior);
 		expect(result.shouldReview).toBe(false);
-		expect(result.reason).toContain('not PR author');
+		expect(result.reason).toContain('no new commits or author comments');
 	});
 
-	it('uses chronological ordering: author comment after approval triggers re-review', async () => {
-		setReviews([
-			{ user: 'carol', state: 'APPROVED', submitted_at: '2025-01-01T10:00:00Z' },
-		]);
-		setComments([
-			{ user: PR_AUTHOR, body: 'Wait, I pushed more changes', created_at: '2025-01-01T14:00:00Z' },
-		]);
+	it('skips when no comments exist and head SHA is unchanged', async () => {
+		setComments([]);
+		const prior = state(SHA_A, '2025-01-01T10:00:00Z');
+		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_A, prior);
+		expect(result.shouldReview).toBe(false);
+		expect(result.reason).toContain('no new commits or author comments');
+	});
 
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
+	it('author comparison is case-insensitive', async () => {
+		setComments([
+			{ user: 'Alice', created_at: '2025-01-01T12:00:00Z' },
+		]);
+		const prior = state(SHA_A, '2025-01-01T10:00:00Z');
+		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_A, prior);
 		expect(result.shouldReview).toBe(true);
 		expect(result.reason).toContain('author commented');
 	});
 
-	it('uses chronological ordering: approval after author comment skips', async () => {
-		setComments([
-			{ user: PR_AUTHOR, body: 'Fixed the issues', created_at: '2025-01-01T10:00:00Z' },
-		]);
-		setReviews([
-			{ user: 'carol', state: 'APPROVED', submitted_at: '2025-01-01T14:00:00Z' },
-		]);
-
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
-		expect(result.shouldReview).toBe(false);
-		expect(result.reason).toContain('approved');
-	});
-
-	it('handles many events and picks the most recent one', async () => {
-		setReviews([
-			{ user: GH_USER, state: 'CHANGES_REQUESTED', submitted_at: '2025-01-01T08:00:00Z' },
-			{ user: 'carol', state: 'COMMENTED', submitted_at: '2025-01-01T09:00:00Z' },
-		]);
-		setComments([
-			{ user: PR_AUTHOR, body: 'Addressed feedback', created_at: '2025-01-01T10:00:00Z' },
-			{ user: 'dave', body: 'Looks good to me, lgtm', created_at: '2025-01-01T11:00:00Z' },
-			{ user: PR_AUTHOR, body: 'One more fix pushed', created_at: '2025-01-01T15:00:00Z' },
-		]);
-
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
-		// Most recent is author's comment at 15:00
-		expect(result.shouldReview).toBe(true);
-		expect(result.reason).toContain('author commented');
-	});
-
-	it('treats someone else\'s non-approval review as needing attention', async () => {
-		setReviews([
-			{ user: 'carol', state: 'CHANGES_REQUESTED', submitted_at: '2025-01-01T12:00:00Z' },
-		]);
+	it('uses --paginate flag when fetching comments', async () => {
 		setComments([]);
+		const prior = state(SHA_A, '2025-01-01T10:00:00Z');
+		await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_A, prior);
 
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
-		expect(result.shouldReview).toBe(true);
-		expect(result.reason).toContain('carol');
-		expect(result.reason).toContain('CHANGES_REQUESTED');
-	});
-
-	it('is case-insensitive for user comparison', async () => {
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, 'Bob', 'bob');
-		expect(result.shouldReview).toBe(false);
-		expect(result.reason).toContain('self-authored');
-	});
-
-	it('uses --paginate flag in API calls', async () => {
-		setReviews([]);
-		setComments([]);
-
-		await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
-
-		// Both gh calls should include --paginate
-		expect(spawnCalls.length).toBe(2);
-		for (const args of spawnCalls) {
-			expect(args).toContain('--paginate');
-		}
-	});
-
-	it('dismiss keyword match is case-insensitive', async () => {
-		setReviews([]);
-		setComments([
-			{ user: 'carol', body: 'APPROVED, Looks Good To Me', created_at: '2025-01-01T12:00:00Z' },
-		]);
-
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
-		expect(result.shouldReview).toBe(false);
-		expect(result.reason).toContain('approve');
-	});
-
-	it('my review followed by dismiss-keyword comment from another user skips', async () => {
-		setReviews([
-			{ user: GH_USER, state: 'CHANGES_REQUESTED', submitted_at: '2025-01-01T10:00:00Z' },
-		]);
-		setComments([
-			{ user: 'carol', body: "Don't merge this yet, wip", created_at: '2025-01-01T12:00:00Z' },
-		]);
-
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
-		expect(result.shouldReview).toBe(false);
-		expect(result.reason).toContain('wip');
+		expect(spawnCalls.length).toBe(1);
+		expect(spawnCalls[0]).toContain('--paginate');
 	});
 
 	it('parses NDJSON multi-page responses from --paginate', async () => {
-		// Simulate gh api --paginate output: each page emits a separate JSON array
 		const page1 = JSON.stringify([
-			{ user: 'carol', state: 'CHANGES_REQUESTED', submitted_at: '2025-01-01T08:00:00Z' },
+			{ user: 'carol', created_at: '2025-01-01T08:00:00Z' },
 		]);
 		const page2 = JSON.stringify([
-			{ user: 'dave', state: 'APPROVED', submitted_at: '2025-01-01T14:00:00Z' },
+			{ user: PR_AUTHOR, created_at: '2025-01-01T14:00:00Z' },
 		]);
-		apiResponses.set(reviewsEndpoint(), `${page1}\n${page2}`);
-		setComments([]);
+		apiResponses.set(commentsEndpoint(), `${page1}\n${page2}`);
 
-		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER);
-		// Most recent review (page 2) is an approval by dave
-		expect(result.shouldReview).toBe(false);
-		expect(result.reason).toContain('approved');
-		expect(result.reason).toContain('dave');
+		const prior = state(SHA_A, '2025-01-01T10:00:00Z');
+		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_A, prior);
+		expect(result.shouldReview).toBe(true);
+		expect(result.reason).toContain('author commented');
+	});
+
+	it('picks a new author comment even when older non-author comments exist', async () => {
+		setComments([
+			{ user: 'carol', created_at: '2025-01-01T11:00:00Z' },
+			{ user: 'dave', created_at: '2025-01-01T11:30:00Z' },
+			{ user: PR_AUTHOR, created_at: '2025-01-01T15:00:00Z' },
+		]);
+		const prior = state(SHA_A, '2025-01-01T10:00:00Z');
+		const result = await shouldReviewPr(OWNER, REPO, PR_NUM, PR_AUTHOR, GH_USER, SHA_A, prior);
+		expect(result.shouldReview).toBe(true);
+		expect(result.reason).toContain('author commented');
 	});
 });


### PR DESCRIPTION
Closes #57.

## Summary

- **Timebox PR search** (`PI_PR_MAX_AGE_DAYS`, default 30) when `assigned_only` is off, via `gh pr list --search created:>=YYYY-MM-DD`.
- **Rework `shouldReviewPr`** to trigger only on (a) brand-new PRs, (b) new commits since the last review, or (c) new author comments since the last review. Drops reviews API call, dismiss-keyword heuristic, third-party review triggers, and non-author comment branches.
- **New `pr_review_state` table** tracking `last_reviewed_head_sha` + `last_reviewed_at` per `pr_url`. `processPrs` reads this before deciding and upserts it after creating a review job.

## Test plan

- [x] `bun run check` — 0 errors
- [x] `bun test src/` — 425 passing (up from 418)
- [x] `shouldReviewPr.test.ts` rewritten for new signature: self-auth, new PR, SHA change, author comment newer/older, non-author comments ignored, pagination, case-insensitive matching, short-circuit behaviour
- [x] `github-pr-poller.test.ts` adds `getPrMaxAgeDays` config tests and `pr_review_state` persistence tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `PI_PR_MAX_AGE_DAYS` environment variable (default: 30 days) to configure the maximum age of pull requests monitored when not using assigned-only filtering.
  * Enhanced pull request review tracking with persistent state storage for improved review accuracy across repository updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->