### PR TITLE
feat: gate job dispatch on CI checks passing

### DIFF
--- a/src/lib/server/gh-utils.ts
+++ b/src/lib/server/gh-utils.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared helpers for invoking the GitHub CLI (`gh`).
+ */
+
+const GH_TIMEOUT_MS = 15_000;
+
+/**
+ * Run `gh` with the given args asynchronously via Bun.spawn.
+ * Returns stdout as a trimmed string, or throws on non-zero exit / timeout.
+ */
+export async function execGh(args: string[]): Promise<string> {
+	const proc = Bun.spawn(['gh', ...args], {
+		stdout: 'pipe',
+		stderr: 'pipe',
+		stdin: 'ignore',
+	});
+
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const result = await Promise.race([
+			(async () => {
+				const [stdout, stderr, exitCode] = await Promise.all([
+					new Response(proc.stdout).text(),
+					new Response(proc.stderr).text(),
+					proc.exited,
+				]);
+				return { stdout, stderr, exitCode };
+			})(),
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => {
+					proc.kill();
+					reject(new Error(`gh ${args[0]} timed out after ${GH_TIMEOUT_MS}ms`));
+				}, GH_TIMEOUT_MS);
+			}),
+		]);
+
+		if (result.exitCode !== 0) {
+			throw new Error(`gh ${args[0]} exited with code ${result.exitCode}: ${result.stderr.trim()}`);
+		}
+
+		return result.stdout.trim();
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
+ * Parse a GitHub PR URL into its owner, repo, and PR number.
+ * Supports URLs like: https://github.com/owner/repo/pull/123
+ * Returns null if the URL doesn't match.
+ */
+export function parsePrUrl(prUrl: string): { owner: string; repo: string; number: number } | null {
+	const match = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+	if (!match) return null;
+	return { owner: match[1], repo: match[2], number: parseInt(match[3], 10) };
+}
+
+/**
+ * Check whether all CI checks on a PR have completed successfully.
+ *
+ * Uses `gh pr checks` which reports the combined status of all commit
+ * status contexts and check runs for the PR's head commit.
+ *
+ * Returns:
+ *   - { ready: true } if all checks have passed (or there are no checks)
+ *   - { ready: false, reason: string } if checks are pending/failing
+ */
+export async function arePrChecksReady(prUrl: string): Promise<{ ready: boolean; reason?: string }> {
+	const parsed = parsePrUrl(prUrl);
+	if (!parsed) {
+		// Can't parse the URL — skip the CI gate rather than blocking forever
+		return { ready: true };
+	}
+
+	try {
+		const output = await execGh([
+			'pr', 'checks', String(parsed.number),
+			'--repo', `${parsed.owner}/${parsed.repo}`,
+			'--json', 'name,state',
+		]);
+
+		const checks = JSON.parse(output || '[]') as Array<{ name: string; state: string }>;
+
+		if (checks.length === 0) {
+			// No checks configured — treat as ready
+			return { ready: true };
+		}
+
+		const pending = checks.filter(c => c.state === 'PENDING' || c.state === 'QUEUED' || c.state === 'IN_PROGRESS');
+		const failed = checks.filter(c => c.state === 'FAILURE' || c.state === 'ERROR');
+
+		if (pending.length > 0) {
+			return {
+				ready: false,
+				reason: `${pending.length} check(s) still running: ${pending.map(c => c.name).join(', ')}`,
+			};
+		}
+
+		if (failed.length > 0) {
+			return {
+				ready: false,
+				reason: `${failed.length} check(s) failed: ${failed.map(c => c.name).join(', ')}`,
+			};
+		}
+
+		// All checks completed with SUCCESS/NEUTRAL/SKIPPED
+		return { ready: true };
+	} catch (err) {
+		// If gh CLI fails, log but don't block — fail open
+		return { ready: true };
+	}
+}

--- a/src/lib/server/gh-utils.ts
+++ b/src/lib/server/gh-utils.ts
@@ -1,6 +1,7 @@
 /**
  * Shared helpers for invoking the GitHub CLI (`gh`).
  */
+import { log } from './logger';
 
 const GH_TIMEOUT_MS = 15_000;
 
@@ -86,27 +87,29 @@ export async function arePrChecksReady(prUrl: string): Promise<{ ready: boolean;
 			return { ready: true };
 		}
 
-		const pending = checks.filter(c => c.state === 'PENDING' || c.state === 'QUEUED' || c.state === 'IN_PROGRESS');
-		const failed = checks.filter(c => c.state === 'FAILURE' || c.state === 'ERROR');
+		const passingStates = ['SUCCESS', 'NEUTRAL', 'SKIPPED'];
+		const nonPassing = checks.filter(c => !passingStates.includes(c.state));
 
-		if (pending.length > 0) {
+		if (nonPassing.length === 0) {
+			return { ready: true };
+		}
+
+		const running = nonPassing.filter(c => ['PENDING', 'QUEUED', 'IN_PROGRESS'].includes(c.state));
+
+		if (running.length > 0) {
 			return {
 				ready: false,
-				reason: `${pending.length} check(s) still running: ${pending.map(c => c.name).join(', ')}`,
+				reason: `${running.length} check(s) still running: ${running.map(c => c.name).join(', ')}`,
 			};
 		}
 
-		if (failed.length > 0) {
-			return {
-				ready: false,
-				reason: `${failed.length} check(s) failed: ${failed.map(c => c.name).join(', ')}`,
-			};
-		}
-
-		// All checks completed with SUCCESS/NEUTRAL/SKIPPED
-		return { ready: true };
-	} catch (err) {
+		return {
+			ready: false,
+			reason: `${nonPassing.length} check(s) failed: ${nonPassing.map(c => `${c.name} (${c.state})`).join(', ')}`,
+		};
+	} catch (err: any) {
 		// If gh CLI fails, log but don't block — fail open
+		log.warn('gh-utils', `CI check query failed for ${prUrl}, proceeding without gate: ${err.message ?? err}`);
 		return { ready: true };
 	}
 }

--- a/src/lib/server/github-pr-poller.ts
+++ b/src/lib/server/github-pr-poller.ts
@@ -22,13 +22,13 @@ import { createJob, findActiveJobByPrUrl } from './job-queue';
 import { REVIEW_SKILL } from './job-prompts';
 import { getHarness } from './rpc-manager';
 import { log } from './logger';
+import { execGh } from './gh-utils';
 
 // --- Constants ---
 
 const DEFAULT_POLL_INTERVAL_SECONDS = 600;
 const DEFAULT_CONCURRENCY = 5;
 const DEFAULT_PR_MAX_AGE_DAYS = 30;
-const GH_TIMEOUT_MS = 15_000;
 
 /** Per-PR error backoff: skip PRs that have failed review-state checks recently. */
 const prErrorBackoff = new Map<string, number>(); // prKey → timestamp when backoff expires
@@ -189,48 +189,6 @@ export function deleteMonitoredRepo(id: string): MonitoredRepo | null {
 		log.info('github-pr-poller', `removed repo ${row.owner}/${row.name}`);
 	}
 	return row;
-}
-
-// --- Async subprocess helper ---
-
-/**
- * Run `gh` with the given args asynchronously via Bun.spawn.
- * Returns stdout as a trimmed string, or throws on non-zero exit / timeout.
- */
-async function execGh(args: string[]): Promise<string> {
-	const proc = Bun.spawn(['gh', ...args], {
-		stdout: 'pipe',
-		stderr: 'pipe',
-		stdin: 'ignore',
-	});
-
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	try {
-		const result = await Promise.race([
-			(async () => {
-				const [stdout, stderr, exitCode] = await Promise.all([
-					new Response(proc.stdout).text(),
-					new Response(proc.stderr).text(),
-					proc.exited,
-				]);
-				return { stdout, stderr, exitCode };
-			})(),
-			new Promise<never>((_, reject) => {
-				timer = setTimeout(() => {
-					proc.kill();
-					reject(new Error(`gh ${args[0]} timed out after ${GH_TIMEOUT_MS}ms`));
-				}, GH_TIMEOUT_MS);
-			}),
-		]);
-
-		if (result.exitCode !== 0) {
-			throw new Error(`gh ${args[0]} exited with code ${result.exitCode}: ${result.stderr.trim()}`);
-		}
-
-		return result.stdout.trim();
-	} finally {
-		clearTimeout(timer);
-	}
 }
 
 // --- GitHub CLI helpers ---

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -10,6 +10,7 @@ import { createSession, sendMessage, stopSession, isActive, getHarness, type Har
 import { log } from './logger';
 import { getDb } from './cache';
 import { existsSync } from 'fs';
+import { arePrChecksReady } from './gh-utils';
 
 // --- Constants ---
 
@@ -145,6 +146,21 @@ export async function pollOnce(): Promise<void> {
 		while (dispatched < MAX_CONCURRENT_CLAIMS) {
 			const job = claimNextJob();
 			if (!job) break; // No more queued jobs
+
+			// Gate: review jobs must wait for all CI checks to pass before dispatch
+			if (job.pr_url) {
+				const ciStatus = await arePrChecksReady(job.pr_url);
+				if (!ciStatus.ready) {
+					// Re-queue the job so it gets picked up in a later poll cycle
+					getDb().query(`
+						UPDATE jobs
+						SET status = 'queued', claimed_at = NULL, updated_at = datetime('now')
+						WHERE id = ?
+					`).run(job.id);
+					log.info('job-poller', `re-queued job ${job.id} — CI not ready: ${ciStatus.reason}`);
+					continue;
+				}
+			}
 
 			await dispatchJob(job);
 			dispatched++;

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -155,7 +155,7 @@ export async function pollOnce(): Promise<void> {
 					getDb().query(`
 						UPDATE jobs
 						SET status = 'queued', claimed_at = NULL, updated_at = datetime('now')
-						WHERE id = ?
+						WHERE id = ? AND status = 'claimed'
 					`).run(job.id);
 					log.info('job-poller', `re-queued job ${job.id} — CI not ready: ${ciStatus.reason}`);
 					dispatched++;

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -147,7 +147,7 @@ export async function pollOnce(): Promise<void> {
 			const job = claimNextJob();
 			if (!job) break; // No more queued jobs
 
-			// Gate: review jobs must wait for all CI checks to pass before dispatch
+			// Gate: jobs with a PR must wait for all CI checks to pass before dispatch
 			if (job.pr_url) {
 				const ciStatus = await arePrChecksReady(job.pr_url);
 				if (!ciStatus.ready) {
@@ -158,6 +158,7 @@ export async function pollOnce(): Promise<void> {
 						WHERE id = ?
 					`).run(job.id);
 					log.info('job-poller', `re-queued job ${job.id} — CI not ready: ${ciStatus.reason}`);
+					dispatched++;
 					continue;
 				}
 			}


### PR DESCRIPTION
## Summary
- Adds a CI gate in the job poller: before dispatching any job with a `pr_url`, checks that all GitHub CI checks have passed via `gh pr checks`
- Jobs with pending/failing CI are re-queued and retried on the next 30s poll cycle
- Extracts `execGh` into a shared `gh-utils.ts` module (was duplicated/private in `github-pr-poller.ts`)

## Test plan
- [x] Typecheck passes (`bunx tsc --noEmit`)
- [x] All 425 existing tests pass (`bun test`)
- [ ] Manual: create a PR with failing CI → verify review job stays queued until CI passes
- [ ] Manual: create a PR with passing CI → verify review job dispatches immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared helper to parse PR URLs and evaluate CI/check readiness for PRs; it logs issues and, if checks can't be determined, defaults to allow progress.
  * Job dispatch now checks CI readiness before sending work: jobs with unready checks are re-queued and retried on the next poll, with logging that records the reason.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->