### PR TITLE
feat: add skip CI checks option for review jobs

### DIFF
--- a/src/lib/components/AddReviewJobModal.svelte
+++ b/src/lib/components/AddReviewJobModal.svelte
@@ -23,6 +23,7 @@
 	let model = $state('');
 	let harness = $state<'pi' | 'claude-code'>('pi');
 	let maxLoops = $state(1);
+	let skipCiChecks = $state(false);
 	let comments = $state('');
 	let creating = $state(false);
 	let errorMsg = $state('');
@@ -37,6 +38,7 @@
 			targetBranch = '';
 			model = '';
 			maxLoops = 1;
+			skipCiChecks = false;
 			comments = '';
 			errorMsg = '';
 		}
@@ -59,6 +61,7 @@
 					branch: branch.trim() || undefined,
 					target_branch: targetBranch.trim() || undefined,
 					max_loops: maxLoops,
+					skip_ci_checks: skipCiChecks || undefined,
 					model: model.trim() || undefined,
 					harness,
 					description: comments.trim() || undefined,
@@ -175,6 +178,24 @@
 						max="20"
 						bind:value={maxLoops}
 					/>
+				</div>
+			</div>
+
+			<!-- Skip CI checks -->
+			<div class="form-control mt-3">
+				<label class="label cursor-pointer justify-start gap-3">
+					<input
+						type="checkbox"
+						class="toggle toggle-sm"
+						bind:checked={skipCiChecks}
+						onchange={() => hapticLight()}
+					/>
+					<span class="label-text">Skip CI checks</span>
+				</label>
+				<div class="label pt-0">
+					<span class="label-text-alt text-base-content/40">
+						Dispatch immediately without waiting for CI to pass
+					</span>
 				</div>
 			</div>
 

--- a/src/lib/server/cache.ts
+++ b/src/lib/server/cache.ts
@@ -114,6 +114,7 @@ export function getDb(): Database {
 		try { db.run("ALTER TABLE jobs ADD COLUMN harness TEXT DEFAULT 'pi'"); } catch {}
 		try { db.run('ALTER TABLE jobs ADD COLUMN analysis_json TEXT'); } catch {}
 		try { db.run('ALTER TABLE jobs ADD COLUMN review_prompt TEXT'); } catch {}
+		try { db.run('ALTER TABLE jobs ADD COLUMN skip_ci_checks INTEGER NOT NULL DEFAULT 0'); } catch {}
 
 		// Migration: Test if 'reviewing' status is allowed by trying a test insert
 		// If it fails, we need to migrate the schema to remove CHECK constraints

--- a/src/lib/server/cache.ts
+++ b/src/lib/server/cache.ts
@@ -163,7 +163,8 @@ export function getDb(): Database {
 				model TEXT,
 				harness TEXT DEFAULT 'pi',
 				analysis_json TEXT,
-				review_prompt TEXT
+				review_prompt TEXT,
+				skip_ci_checks INTEGER NOT NULL DEFAULT 0
 			)`);
 			// Copy data — match only columns present in both old and new tables
 			const oldCols = (db.query("PRAGMA table_info(jobs)").all() as { name: string }[]).map(c => c.name);

--- a/src/lib/server/job-poller.ts
+++ b/src/lib/server/job-poller.ts
@@ -149,7 +149,7 @@ export async function pollOnce(): Promise<void> {
 			if (!job) break; // No more queued jobs
 
 			// Gate: jobs with a PR must wait for all CI checks to pass before dispatch
-			if (job.pr_url) {
+			if (job.pr_url && !job.skip_ci_checks) {
 				const ciStatus = await arePrChecksReady(job.pr_url);
 				if (!ciStatus.ready) {
 					// Re-queue the job so it gets picked up in a later poll cycle

--- a/src/lib/server/job-prompts.test.ts
+++ b/src/lib/server/job-prompts.test.ts
@@ -37,6 +37,7 @@ function makeJob(overrides?: Partial<Job>): Job {
 		harness: 'pi',
 		analysis_json: null,
 		review_prompt: null,
+		skip_ci_checks: 0,
 		...overrides,
 	};
 }

--- a/src/lib/server/job-queue.ts
+++ b/src/lib/server/job-queue.ts
@@ -41,6 +41,7 @@ export interface Job {
 	harness: string | null;
 	analysis_json: string | null;
 	review_prompt: string | null;
+	skip_ci_checks: number;
 }
 
 export interface CreateJobInput {
@@ -58,6 +59,7 @@ export interface CreateJobInput {
 	pr_url?: string;
 	model?: string;
 	harness?: string;
+	skip_ci_checks?: boolean;
 }
 
 export interface UpdateJobInput {
@@ -82,8 +84,8 @@ export interface UpdateJobInput {
 
 function insertJobQuery() {
 	return getDb().query(`
-		INSERT INTO jobs (type, title, description, repo, branch, issue_url, target_branch, priority, parent_job_id, loop_count, max_loops, pr_url, model, harness)
-		VALUES ($type, $title, $description, $repo, $branch, $issue_url, $target_branch, $priority, $parent_job_id, $loop_count, $max_loops, $pr_url, $model, $harness)
+		INSERT INTO jobs (type, title, description, repo, branch, issue_url, target_branch, priority, parent_job_id, loop_count, max_loops, pr_url, model, harness, skip_ci_checks)
+		VALUES ($type, $title, $description, $repo, $branch, $issue_url, $target_branch, $priority, $parent_job_id, $loop_count, $max_loops, $pr_url, $model, $harness, $skip_ci_checks)
 		RETURNING *
 	`);
 }
@@ -131,6 +133,7 @@ export function createJob(input: CreateJobInput): Job {
 		$pr_url: input.pr_url ?? null,
 		$model: input.model ?? null,
 		$harness: input.harness ?? 'pi',
+		$skip_ci_checks: input.skip_ci_checks ? 1 : 0,
 	}) as Job;
 
 	log.info('job-queue', `created job ${row.id} (${row.type ?? 'task'}): ${row.title}`);

--- a/src/routes/api/jobs/+server.ts
+++ b/src/routes/api/jobs/+server.ts
@@ -22,7 +22,7 @@ export const GET: RequestHandler = async ({ url }) => {
 export const POST: RequestHandler = async ({ request }) => {
 	try {
 		const body = await request.json();
-		const { type, title, description, repo, branch, issue_url, target_branch, priority, max_loops, pr_url, model, harness } = body;
+		const { type, title, description, repo, branch, issue_url, target_branch, priority, max_loops, pr_url, model, harness, skip_ci_checks } = body;
 
 		// Type is now optional (defaults to 'task' in createJob)
 		if (type && !['task', 'review'].includes(type)) {
@@ -96,6 +96,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			pr_url: trimmedPrUrl,
 			model: model?.trim() || undefined,
 			harness: harness || undefined,
+			skip_ci_checks: skip_ci_checks === true,
 		});
 
 		return json({ job }, { status: 201 });


### PR DESCRIPTION
## Summary
- Adds a `skip_ci_checks` column to the jobs table (integer, default 0)
- Review job modal gets a "Skip CI checks" toggle that dispatches immediately without waiting for CI to pass
- Poller respects the flag — skips the `arePrChecksReady` gate when set

## Test plan
- [ ] Create a review job with "Skip CI checks" toggled on — verify it dispatches without waiting for CI
- [ ] Create a review job with the toggle off (default) — verify CI gate still applies
- [ ] Verify `bun run check` passes with zero type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Skip CI checks" option in the job modal with helper text and haptic feedback; when enabled, jobs dispatch immediately without waiting for CI.
* **Behavior**
  * The skip setting is persisted and honored by the dispatch process so enabled jobs bypass CI gating.
* **Tests**
  * Updated tests to include the new skip flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->