### PR TITLE
fix: instruct reviewer to consider PR conversation context

### DIFF
--- a/src/lib/server/job-prompts.ts
+++ b/src/lib/server/job-prompts.ts
@@ -138,6 +138,14 @@ export function buildReviewPrompt(job: Job, _harness: string = 'pi', analysis?: 
 	if (job.pr_url) parts.push(`PR: ${job.pr_url}`);
 
 	parts.push('');
+	parts.push('=== PR CONVERSATION CONTEXT ===');
+	parts.push('Before finalizing your review, read through the existing PR comments and conversation.');
+	parts.push('Pay close attention to messages that directly address or respond to previously raised issues.');
+	parts.push('If an issue from a prior review has been acknowledged, explained, or resolved in the');
+	parts.push('conversation, do NOT re-raise it unless the response is insufficient or the fix is incorrect.');
+	parts.push('Your review should focus on the current state of the code and any unresolved concerns.');
+	parts.push('================================');
+	parts.push('');
 	parts.push('=== CRITICAL: REQUIRED STEPS ===');
 	parts.push('After completing the review, you MUST do BOTH of these steps IN ORDER:');
 	parts.push('');


### PR DESCRIPTION
## Summary
- Adds a `PR CONVERSATION CONTEXT` section to the review prompt instructing the reviewer to read existing PR comments before finalizing
- Prevents the reviewer from redundantly re-raising issues that have already been acknowledged, explained, or resolved in the conversation
- Review focus stays on the current state of the code and genuinely unresolved concerns

## Test plan
- [x] Existing `job-prompts` tests pass
- [ ] Verify review agent reads PR comments and skips resolved issues in a live review loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI code reviews now incorporate prior PR conversation history to avoid repeating previously addressed feedback and focus on unresolved concerns and current code state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->